### PR TITLE
[portable-rustls] no features enabled by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,6 +148,7 @@ jobs:
         with:
           target: x86_64-unknown-none
 
+      # NOTE: no features are enabled by default on main crate in this fork
       - name: cargo build (debug; default features)
         run: cargo build --locked
         working-directory: rustls
@@ -155,13 +156,16 @@ jobs:
         # this target does _not_ include the libstd crate in its sysroot
         # it will catch unwanted usage of libstd in _dependencies_
       - name: cargo build (debug; no default features; no-std)
+        # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo build --locked --no-default-features --target x86_64-unknown-none
         working-directory: rustls
 
       - name: cargo build (debug; no default features; no-std, hashbrown)
+        # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo build --locked --no-default-features --features hashbrown --target x86_64-unknown-none
         working-directory: rustls
 
+      # NOTE: no features are enabled by default on main crate in this fork
       - name: cargo test (debug; default features)
         run: cargo test --locked
         working-directory: rustls
@@ -169,14 +173,17 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: cargo test (debug; no default features)
+        # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo test --locked --no-default-features
         working-directory: rustls
 
       - name: cargo test (debug; no default features; tls12)
+        # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo test --locked --no-default-features --features tls12,std
         working-directory: rustls
 
       - name: cargo test (debug; no default features; aws-lc-rs,tls12)
+        # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo test --no-default-features --features aws_lc_rs,tls12,std
         working-directory: rustls
 
@@ -184,6 +191,7 @@ jobs:
       # - name: cargo test (debug; no default features; fips,tls12)
       #   ...
 
+      # NOTE: no features are enabled by default on main crate in this fork
       - name: cargo test (release; no run)
         run: cargo test --locked --release --no-run
         working-directory: rustls

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ IMPORTANT NOTICE: REGARDLESS OF UPSTREAM `rustls` PROJECT THIS FORK IS NOT CERTI
 <!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
 RECOMMENDED USAGE OF THIS FORK (as stated further below):
 * USE DEPENDENCY LIKE THIS IN `Cargo.toml`: `rustls = { package = "portable-rustls", ... }`
+* NEED TO EXPLICITLY ENABLE ANY FEATURES AS NEEDED - NO FEATURES ARE ENABLED BY DEFAULT IN THIS FORK
 * IMPORT AS USUAL FROM `rustls`: `use rustls;` OR `use rustls::...`
 
 ADDITIONAL NOTE (as stated further below): FIPS SUPPORT IS REMOVED FROM THIS FORK. THERE MAY BE SOME VESTIGES IN THE API,
@@ -75,6 +76,7 @@ IMPORTANT NOTICE: REGARDLESS OF UPSTREAM `rustls` PROJECT THIS FORK IS NOT CERTI
 <!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE FOR THIS FORK -->
 RECOMMENDED USAGE OF THIS FORK:
 * USE DEPENDENCY LIKE THIS IN `Cargo.toml`: `rustls = { package = "portable-rustls", ... }`
+* NEED TO EXPLICITLY ENABLE ANY FEATURES AS NEEDED - NO FEATURES ARE ENABLED BY DEFAULT IN THIS FORK
 * IMPORT AS USUAL FROM `rustls`: `use rustls;` OR `use rustls::...`
 
 ADDITIONAL NOTE: FIPS SUPPORT IS REMOVED FROM THIS FORK. THERE MAY BE SOME VESTIGES IN THE API,
@@ -91,8 +93,11 @@ list of protocol features](https://docs.rs/rustls/latest/rustls/manual/_04_featu
 
 ### Platform support
 
-While Rustls itself is platform independent, by default it uses [`aws-lc-rs`] for implementing
-the cryptography in TLS.  See [the aws-lc-rs FAQ][aws-lc-rs-platforms-faq] for more details of the
+While Rustls itself is platform independent, there are some additional platform requirements
+for the built-in providers.
+
+[`aws-lc-rs`] is commonly used as the provider that implements the cryptography in TLS.
+See [the aws-lc-rs FAQ][aws-lc-rs-platforms-faq] for more details of the
 platform/architecture support constraints in aws-lc-rs.
 
 [`ring`] is also available via the `ring` crate feature: see
@@ -126,9 +131,10 @@ builder types. See the [`crypto::CryptoProvider`] documentation for more details
 
 #### Built-in providers
 
-Rustls ships with two built-in providers controlled by associated crate features:
+Rustls ships with two built-in providers controlled by associated crate features,
+which are both optional in this fork:
 
-* [`aws-lc-rs`] - enabled by default, available with the `aws_lc_rs` crate feature enabled.
+* [`aws-lc-rs`] - available with the `aws-lc-rs` crate feature enabled.
 * [`ring`] - available with the `ring` crate feature enabled.
 
 See the documentation for [`crypto::CryptoProvider`] for details on how providers are

--- a/bogo/Cargo.toml
+++ b/bogo/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 base64 = { workspace = true }
 env_logger = { workspace = true }
 # WITH ADAPTED MAIN PACKAGE NAME for this fork
-rustls = { package = "portable-rustls", path = "../rustls", features = ["aws_lc_rs", "ring", "tls12"] }
+rustls = { package = "portable-rustls", path = "../rustls", features = ["aws-lc-rs", "ring", "std", "tls12"] }
 rustls-post-quantum = { path = "../rustls-post-quantum", optional = true }
 
 [features]

--- a/ci-bench/Cargo.toml
+++ b/ci-bench/Cargo.toml
@@ -15,7 +15,7 @@ fxhash = { workspace = true }
 itertools = { workspace = true }
 rayon = { workspace = true }
 # WITH ADAPTED MAIN PACKAGE NAME for this fork
-rustls = { package = "portable-rustls", path = "../rustls", features = ["ring", "aws_lc_rs"] }
+rustls = { package = "portable-rustls", path = "../rustls", features = ["aws-lc-rs", "ring", "std", "tls12"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,7 @@ log = { workspace = true }
 mio = { workspace = true }
 rcgen = { workspace = true }
 # WITH ADAPTED MAIN PACKAGE NAME for this fork
-rustls = { package = "portable-rustls", path = "../rustls", features = ["logging"] }
+rustls = { package = "portable-rustls", path = "../rustls", features = ["aws-lc-rs", "std", "tls12"] }
 serde = { workspace = true }
 tokio = { workspace = true }
 webpki-roots = { workspace = true }

--- a/openssl-tests/Cargo.toml
+++ b/openssl-tests/Cargo.toml
@@ -12,5 +12,5 @@ base64 = { workspace = true }
 num-bigint = { workspace = true }
 once_cell = { workspace = true }
 # WITH ADAPTED MAIN PACKAGE NAME for this fork
-rustls = { package = "portable-rustls", path = "../rustls" }
+rustls = { package = "portable-rustls", path = "../rustls", features = ["aws-lc-rs", "std", "tls12"] }
 openssl = { workspace = true }

--- a/rustls-bench/Cargo.toml
+++ b/rustls-bench/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = { workspace = true }
-rustls = { package = "portable-rustls", path = "../rustls" }
+rustls = { package = "portable-rustls", path = "../rustls", features = ["std", "tls12"] }
 rustls-post-quantum = { path = "../rustls-post-quantum", optional = true }
 
 [features]

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -14,7 +14,11 @@ autobenches = false
 
 [dependencies]
 # WITH ADAPTED MAIN PACKAGE NAME for this fork (MISSING version - should be OK in this fork)
-rustls = { features = ["aws_lc_rs", "prefer-post-quantum"], package = "portable-rustls", path = "../rustls" }
+rustls = { package = "portable-rustls", path = "../rustls", features = [
+  "aws-lc-rs",
+  "prefer-post-quantum",
+  "std",
+] }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -16,15 +16,15 @@ exclude = ["src/testdata", "tests/**"]
 build = "build.rs"
 
 [features]
-default = ["aws_lc_rs", "logging", "std", "tls12"]
+default = []
 
-aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
+aws-lc-rs = ["aws_lc_rs"] # ALIAS - FAVORED OVER `aws_lc_rs` FEATURE NAME IN THIS FORK
 aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
 custom-provider = []
 # [FIPS REMOVED FROM THIS FORK] fips = ...
 logging = ["log"]
-prefer-post-quantum = ["aws_lc_rs"]
+prefer-post-quantum = ["aws-lc-rs"]
 read_buf = ["rustversion", "std"]
 ring = ["dep:ring", "webpki/ring"]
 std = ["webpki/std", "pki-types/std", "once_cell/std"]

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -107,7 +107,8 @@ impl EchConfig {
 
         // Note: we name the index var _i because if the log feature is disabled
         //       it is unused.
-        #[cfg_attr(not(feature = "std"), allow(clippy::unused_enumerate_index))]
+        // WITH UPDATED FEATURE CONDITION TO AVOID CI CLIPPY ISSUE IN THIS FORK
+        #[cfg_attr(not(feature = "logging"), allow(clippy::unused_enumerate_index))]
         for (_i, config) in ech_configs.iter().enumerate() {
             let contents = match config {
                 EchConfigPayload::V18(contents) => contents,

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -61,11 +61,11 @@ pub use crate::suites::CipherSuiteCommon;
 /// This crate comes with two built-in options, provided as
 /// `CryptoProvider` structures:
 ///
-/// - [`crypto::aws_lc_rs::default_provider`]: (behind the `aws_lc_rs` crate feature,
-///   which is enabled by default).  This provider uses the [aws-lc-rs](https://github.com/aws/aws-lc-rs)
+/// - [`crypto::aws_lc_rs::default_provider`] (behind the optional `aws-lc-rs` crate feature):
+///   This provider uses the [aws-lc-rs](https://github.com/aws/aws-lc-rs)
 ///   crate.  The `fips` crate feature makes this option use FIPS140-3-approved cryptography.
-/// - [`crypto::ring::default_provider`]: (behind the `ring` crate feature, which
-///   is optional).  This provider uses the [*ring*](https://github.com/briansmith/ring)
+/// - [`crypto::ring::default_provider`] (behind the optional `ring` crate feature):
+///   This provider uses the [*ring*](https://github.com/briansmith/ring)
 ///   crate.
 ///
 /// This structure provides defaults. Everything in it can be overridden at

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -6,6 +6,7 @@
 //! <!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE FOR THIS FORK -->
 //! RECOMMENDED USAGE OF THIS FORK:
 //! * USE DEPENDENCY LIKE THIS IN `Cargo.toml`: `rustls = { package = "portable-rustls", ... }`
+//! * NEED TO EXPLICITLY ENABLE ANY FEATURES AS NEEDED - NO FEATURES ARE ENABLED BY DEFAULT IN THIS FORK
 //! * IMPORT AS USUAL FROM `rustls`: `use rustls;` OR `use rustls::...`
 //!
 //! ADDITIONAL NOTE: FIPS SUPPORT IS REMOVED FROM THIS FORK. THERE MAY BE SOME VESTIGES IN THE API,
@@ -22,8 +23,11 @@
 //!
 //! ### Platform support
 //!
-//! While Rustls itself is platform independent, by default it uses [`aws-lc-rs`] for implementing
-//! the cryptography in TLS.  See [the aws-lc-rs FAQ][aws-lc-rs-platforms-faq] for more details of the
+//! While Rustls itself is platform independent, there are some additional platform requirements
+//! for the built-in providers.
+//!
+//! [`aws-lc-rs`] is commonly used as the provider that implements the cryptography in TLS.
+//! See [the aws-lc-rs FAQ][aws-lc-rs-platforms-faq] for more details of the
 //! platform/architecture support constraints in aws-lc-rs.
 //!
 //! [`ring`] is also available via the `ring` crate feature: see
@@ -57,9 +61,10 @@
 //!
 //! #### Built-in providers
 //!
-//! Rustls ships with two built-in providers controlled by associated crate features:
+//! Rustls ships with two built-in providers controlled by associated crate features,
+//! which are both optional in this fork:
 //!
-//!   * [`aws-lc-rs`] - enabled by default, available with the `aws_lc_rs` crate feature enabled.
+//!   * [`aws-lc-rs`] - available with the `aws-lc-rs` crate feature enabled.
 //!   * [`ring`] - available with the `ring` crate feature enabled.
 //!
 //! See the documentation for [`crypto::CryptoProvider`] for details on how providers are
@@ -296,10 +301,10 @@
 //! Here's a list of what features are exposed by the rustls crate and what
 //! they mean.
 //!
-//! - `std` (enabled by default): enable the high-level (buffered) Connection API and other functionality
+//! - `std`: enable the high-level (buffered) Connection API and other functionality
 //!   which relies on the `std` library.
 //!
-//! - `aws_lc_rs` (enabled by default): makes the rustls crate depend on the [`aws-lc-rs`] crate.
+//! - `aws-lc-rs`: makes the rustls crate depend on the [`aws-lc-rs`] crate.
 //!   Use `rustls::crypto::aws_lc_rs::default_provider().install_default()` to
 //!   use it as the default `CryptoProvider`, or provide it explicitly
 //!   when making a `ClientConfig` or `ServerConfig`.
@@ -314,7 +319,7 @@
 //!
 //! <!-- [FIPS REMOVED FROM THIS FORK]
 //! - `fips`: enable support for FIPS140-3-approved cryptography, via the [`aws-lc-rs`] crate.
-//!   This feature enables the `aws_lc_rs` crate feature, which makes the rustls crate depend
+//!   This feature enables the `aws-lc-rs` crate feature, which makes the rustls crate depend
 //!   on [aws-lc-rs](https://github.com/aws/aws-lc-rs).  It also changes the default
 //!   for [`ServerConfig::require_ems`] and [`ClientConfig::require_ems`].
 //!
@@ -327,16 +332,18 @@
 //!   to the default set in a future minor release.  See [the manual][x25519mlkem768-manual]
 //!   for more details.
 //!
-//! - `custom-provider`: disables implicit use of built-in providers (`aws-lc-rs` or `ring`). This forces
+//! <!-- UPDATED DESCRIPTION FOR THIS FORK -->
+//! - `custom-provider`: disables implicit use of any built-in providers
+//!   (`aws-lc-rs` or `ring`), if enabled by crate features. This forces
 //!   applications to manually install one, for instance, when using a custom `CryptoProvider`.
 //!
-//! - `tls12` (enabled by default): enable support for TLS version 1.2. Note that, due to the
+//! - `tls12`: enable support for TLS version 1.2. Note that, due to the
 //!   additive nature of Cargo features and because it is enabled by default, other crates
 //!   in your dependency graph could re-enable it for your application. If you want to disable
 //!   TLS 1.2 for security reasons, consider explicitly enabling TLS 1.3 only in the config
 //!   builder API.
 //!
-//! - `logging` (enabled by default): make the rustls crate depend on the `log` crate.
+//! - `logging`: make the rustls crate depend on the `log` crate.
 //!   rustls outputs interesting protocol-level messages at `trace!` and `debug!` level,
 //!   and protocol-level errors at `warn!` and `error!` level.  The log messages do not
 //!   contain secret key data, and so are safe to archive without affecting session security.

--- a/rustls/src/server/tls12.rs
+++ b/rustls/src/server/tls12.rs
@@ -907,11 +907,15 @@ impl State<ServerConnectionData> for ExpectFinished {
 
             let value = get_server_connection_value_tls12(&self.secrets, self.using_ems, cx, now);
 
-            let worked = self
+            // UPDATED VARIABLE NAME WITH UNDERSCORE TO AVOID CI CLIPPY ISSUE IN THIS FORK
+            let _is_saved = self
                 .config
                 .session_storage
                 .put(self.session_id.as_ref().to_vec(), value.get_encoding());
-            if worked {
+
+            // WITH FEATURE CONDITION TO AVOID CI CLIPPY ISSUE IN THIS FORK
+            #[cfg(feature = "logging")]
+            if _is_saved {
                 debug!("Session saved");
             } else {
                 debug!("Session not saved");


### PR DESCRIPTION
__WHAT (DESCRIPTION)__

(see title)

---

__WHY__

rationale: as `portable-rustls` is intended for embedded systems, I would like to encourage no optional features by default

---

__caveat(s):__
- need to keep docsrs configuration & CI docs configuration in sync to ensure all features are properly documented - _this caveat will likely go away once PR #7 is merged_
- This may have some effect on CI testing. I do expect this to be somewhat limited as many CI tests either use `--no-default-features` or `--all-features` (or `admin/all-features-except`)

---

__TODO__

- [x] should merge other PR #7 first to simplify doc build & remove a caveat described above
- [ ] resolve any XXX todo items in these updates
- [ ] ensure CI remains green with these changes