### PR TITLE
[portable-rustls] add CI build testing for multiple targets with no atomic ptr (src update deferred) - CI FAILURE EXPECTED

### DIFF
--- a/.github/workflows/portable-rustls-ci-build.yml
+++ b/.github/workflows/portable-rustls-ci-build.yml
@@ -1,0 +1,85 @@
+name: portable-rustls CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches-ignore:
+    - 'gh-readonly-queue/**'
+    tags:
+    - '**'
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 18 * * *'
+
+# XXX TBD ??? ???
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  # XXX XXX
+  # cancel-in-progress: true
+
+jobs:
+  # XXX TBD JOB NAMING - ???
+  portable-build:
+    name: Portable build test
+    runs-on: ubuntu-latest
+    strategy:
+      # XXX TBD ??? ???
+      # fail-fast: false
+      matrix:
+        target:
+          # 32-bit target(s) with no atomic ptr:
+          - riscv32imc-unknown-none-elf
+          # XXX TBD OTHER TARGET(S) - ???
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          target: ${{ matrix.target }}
+
+      # XXX TBD PARTIAL BUILD WORKAROUNDS - XXX TBD add feature(s) to configure these Cargo updates - ???
+      - run: cargo add once_cell -F critical-section -p portable-rustls
+      - run: cargo add portable-atomic -F critical-section -p portable-rustls
+
+      - name: cargo build (debug; no default features; no-std) # no std; no built-in provider
+        run: cargo build --locked --no-default-features --target ${{ matrix.target }}
+        working-directory: rustls
+
+      # XXX TODO: TRY BUILDING with hashbrown & include a built-in provider (aws-lc-rs or ring), if possible
+
+  cross-build:
+    name: cross build testing
+    runs-on: ubuntu-latest
+    # XXX TBD KEEP if: here - ???
+    if: github.event_name != 'merge_group'
+    strategy:
+      # XXX KEEP FOR NOW TO SEE EXPECTED BUILD FAILURE ONLY FOR TARGET(S) WITH NO ATOMIC PTR
+      fail-fast: false
+      matrix:
+        target:
+          # 32-bit Android (Linux) targets:
+          - armv7-linux-androideabi
+          # 32-bit target(s) with no atomic ptr:
+          - thumbv6m-none-eabi
+          # XXX TBD OTHER TARGET(S) - ???
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install rust-toolchain - nightly # XXX TBD for unstable features (...)
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Install cross (cross-rs) from GitHub
+        run: cargo install cross --git https://github.com/cross-rs/cross
+      # XXX TBD PARTIAL BUILD WORKAROUNDS - XXX TBD add feature(s) to configure these Cargo updates - ???
+      - run: cargo add once_cell -F critical-section -p portable-rustls
+      - run: cargo add portable-atomic -F critical-section -p portable-rustls
+      - run: cross build --no-default-features --package portable-rustls --target ${{ matrix.target }}


### PR DESCRIPTION
__STATUS:__

- [ ] EXPECTED to FAIL at this point - should fail due to missing `Arc` for target with no atomic ptr - need to check recent updates

__DEFERRED ITEMS - deferred to another PR:__

- [ ] TODO: use `portable_atomic_util::Arc` to resolve this issue
- [ ] TODO: update documentation

__OPEN QUESTION(S):__

- [ ] feature-based configuration to select "std" Arc (alloc::sync::Arc) vs portable-atomic (portable-atomic-util) Arc - may be able to defer this
- [ ] add some kind of "critical-section" feature to enable "critical-section" in once_cell & possible transitive portable-atomic dep(s) - may be able to defer this
- [ ] always use once_cell sync feature instead of once_cell::race if "critical-section" feature is enabled - this looks like a pretty small but nice optimization