### PR TITLE
fix spelling in comments: targeting - found by VS Code Spell Check extension - TODO raise this upstream

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -2,5 +2,5 @@ upper-case-acronyms-aggressive = true
 
 # only intended to affect main rustls crate - need to allow disallowed-types in all other crates in Clippy CI job
 disallowed-types = [
-  { path = "std::sync::Arc", reason = "must use Arc from sync module to support downstream forks targetting architectures without atomic ptrs" },
+  { path = "std::sync::Arc", reason = "must use Arc from sync module to support downstream forks targeting architectures without atomic ptrs" },
 ]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -424,7 +424,7 @@ mod log {
 mod test_macros;
 
 /// This internal `sync` module aliases the `Arc` implementation to allow downstream forks
-/// of rustls targetting architectures without atomic pointers to replace the implementation
+/// of rustls targeting architectures without atomic pointers to replace the implementation
 /// with another implementation such as `portable_atomic_util::Arc` in one central location.
 mod sync {
     #[allow(clippy::disallowed_types)]


### PR DESCRIPTION
found another reference: https://www.collinsdictionary.com/us/dictionary/english/targeting

TODO:

- [ ] raise this to upstream rustls
- [ ] consider using typos and/or spell checker in upstream rustls CI