### PR TITLE
[portable-rustls] remove fips feature; simplify doc build; etc.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,21 +60,18 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1
 
-      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
-        if: runner.os == 'Windows'
-        uses: seanmiddleditch/gha-setup-ninja@v6
+      # [FIPS REMOVED FROM THIS FORK]
+      # - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+      #   ...
 
-      - name: Install golang for aws-lc-fips-sys on macos
-        if: runner.os == 'MacOS'
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.22.2"
+      # [FIPS REMOVED FROM THIS FORK]
+      # - name: Install golang for aws-lc-fips-sys on macos
+      #   ...
 
       - name: cargo build (debug; default features)
         run: cargo build --locked
 
-      # nb. feature sets that include "fips" should be --release --
-      # this is required for fips on windows.
+      # N/A [FIPS REMOVED FROM THIS FORK]: nb. feature sets that include "fips" ...
       # nb. "--all-targets" does not include doctests
       - name: cargo test (release; all features)
         run: cargo test --release --locked --all-features --all-targets
@@ -93,10 +90,9 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-      - name: cargo test (release; fips)
-        run: cargo test --release --no-default-features --features fips,tls12,read_buf,logging,std --all-targets
-        env:
-          RUST_BACKTRACE: 1
+      # [FIPS REMOVED FROM THIS FORK]
+      # - name: cargo test (release; fips)
+      #   ...
 
       - name: cargo build (debug; rustls-provider-example)
         run: cargo build --locked -p rustls-provider-example
@@ -184,9 +180,9 @@ jobs:
         run: cargo test --no-default-features --features aws_lc_rs,tls12,std
         working-directory: rustls
 
-      - name: cargo test (debug; no default features; fips,tls12)
-        run: cargo test --no-default-features --features fips,tls12,std
-        working-directory: rustls
+      # [FIPS REMOVED FROM THIS FORK]
+      # - name: cargo test (debug; no default features; fips,tls12)
+      #   ...
 
       - name: cargo test (release; no run)
         run: cargo test --locked --release --no-run
@@ -222,11 +218,9 @@ jobs:
         env:
           BOGO_SHIM_PROVIDER: aws-lc-rs
 
-      - name: Run test suite (aws-lc-rs-fips)
-        working-directory: bogo
-        run: ./runme
-        env:
-          BOGO_SHIM_PROVIDER: aws-lc-rs-fips
+      # [FIPS REMOVED FROM THIS FORK]
+      # - name: Run test suite (aws-lc-rs-fips)
+      #   ...
 
       - name: Run test suite (post-quantum)
         working-directory: bogo
@@ -274,8 +268,9 @@ jobs:
       - name: Smoke-test benchmark program (aws-lc-rs)
         run: cargo run -p rustls-bench --profile=bench --locked --features aws-lc-rs -- --multiplier 0.1
 
-      - name: Smoke-test benchmark program (fips)
-        run: cargo run -p rustls-bench --profile=bench --locked --features fips -- --provider aws-lc-rs-fips --multiplier 0.1
+      # [FIPS REMOVED FROM THIS FORK]
+      # - name: Smoke-test benchmark program (fips)
+      #   ...
 
       - name: Run micro-benchmarks
         run: cargo bench --locked --all-features

--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -44,9 +44,9 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1
 
-      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
-        if: runner.os == 'Windows'
-        uses: seanmiddleditch/gha-setup-ninja@v6
+      # [FIPS REMOVED FROM THIS FORK]
+      # - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+      #   ...
 
       - name: Build example programs
         run: cargo build --locked -p rustls-examples
@@ -88,9 +88,9 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1
 
-      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
-        if: runner.os == 'Windows'
-        uses: seanmiddleditch/gha-setup-ninja@v6
+      # [FIPS REMOVED FROM THIS FORK]
+      # - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+      #   ...
 
       - name: Check simple client
         run: cargo run --locked -p rustls-examples --bin simpleclient
@@ -167,20 +167,18 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1
 
-      # FOR FEATURE POWERSET CI ON WINDOWS IN THIS FORK
-      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
-        if: runner.os == 'Windows'
-        uses: seanmiddleditch/gha-setup-ninja@v6
+      # FOR FEATURE POWERSET CI ON WINDOWS IN THIS FORK - NO LONGER NEEDED [FIPS REMOVED FROM THIS FORK]
+      # - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+      #   ...
 
       - name: Check feature powerset
+        # REMOVED cargo hack check --...features OPTIONS FOR `fips` [FIPS REMOVED FROM THIS FORK]
         run: >
             cargo hack check
             --package portable-rustls
             --feature-powerset
             --no-dev-deps
             --group-features aws_lc_rs,aws-lc-rs
-            --group-features fips,aws_lc_rs
-            --mutually-exclusive-features fips,ring
             --mutually-exclusive-features custom_provider,aws_lc_rs
             --mutually-exclusive-features custom_provider,ring
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   push:
-    # GONE FROM THIS FORK:
+    # [REMOVED FROM THIS FORK]
     # branches:
     #   - main
   schedule:
@@ -25,7 +25,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      # GONE FROM THIS FORK:
+      # [REMOVED FROM THIS FORK]
       # - name: Install zola
       # ...
 
@@ -38,18 +38,19 @@ jobs:
             "</script>"
 
       - name: cargo doc
-        # keep features in sync with Cargo.toml `[package.metadata.docs.rs]` section
-        run: cargo doc --locked --features read_buf,ring --no-deps --package portable-rustls
+        # (CARGO DOC WITH ALL FEATURES IN THIS FORK)
+        run: cargo doc --locked --all-features --no-deps --package portable-rustls
         env:
           RUSTDOCFLAGS: -Dwarnings --cfg=docsrs --html-after-content tag.html
 
-      # GONE FROM THIS FORK: Generate other pages for website (etc.)
+      # [REMOVED FROM THIS FORK] Generate other pages for website (etc.)
 
+  # SKIPPING CI JOB IN THIS FORK, AS CONFIGURED BELOW (FOR FUTURE CONSIDERATION)
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    # SKIP IN THIS FORK
-    # if: github.repository == 'rustls/rustls'
+    # [CONFIG TO SKIP CI JOB IN THIS FORK]
+    # if: github.repository == ...
     if: false
     needs: generate
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,28 +356,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "aws-lc-fips-sys"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59057b878509d88952425fe694a2806e468612bde2d71943f3cd8034935b5032"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "libc",
- "paste",
- "regex",
-]
-
-[[package]]
 name = "aws-lc-rs"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
 dependencies = [
- "aws-lc-fips-sys",
  "aws-lc-sys",
  "paste",
  "zeroize",

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ RECOMMENDED USAGE OF THIS FORK (as stated further below):
 * USE DEPENDENCY LIKE THIS IN `Cargo.toml`: `rustls = { package = "portable-rustls", ... }`
 * IMPORT AS USUAL FROM `rustls`: `use rustls;` OR `use rustls::...`
 
+ADDITIONAL NOTE (as stated further below): FIPS SUPPORT IS REMOVED FROM THIS FORK. THERE MAY BE SOME VESTIGES IN THE API,
+IMPLEMENTATION OR DOCUMENTATION BUT THIS DOES NOT IMPLY EXISTENCE OF FIPS SUPPORT IN ANY FORM.
+
 # Status
 
 <!-- TODO(portable-rustls) UPDATE & CLEAN UP INFO FOR THIS FORK -->
@@ -73,6 +76,9 @@ IMPORTANT NOTICE: REGARDLESS OF UPSTREAM `rustls` PROJECT THIS FORK IS NOT CERTI
 RECOMMENDED USAGE OF THIS FORK:
 * USE DEPENDENCY LIKE THIS IN `Cargo.toml`: `rustls = { package = "portable-rustls", ... }`
 * IMPORT AS USUAL FROM `rustls`: `use rustls;` OR `use rustls::...`
+
+ADDITIONAL NOTE: FIPS SUPPORT IS REMOVED FROM THIS FORK. THERE MAY BE SOME VESTIGES IN THE API,
+IMPLEMENTATION OR DOCUMENTATION BUT THIS DOES NOT IMPLY EXISTENCE OF FIPS SUPPORT IN ANY FORM.
 
 <!-- TODO(portable-rustls) UPDATE INFO FOR THIS FORK -->
 Rustls is a TLS library that aims to provide a good level of cryptographic security,

--- a/admin/coverage
+++ b/admin/coverage
@@ -7,7 +7,8 @@ cargo llvm-cov clean --workspace
 
 cargo build --locked --all-targets --all-features
 cargo test --locked --all-features
-cargo test -p portable-rustls --locked --no-default-features --features tls12,logging,aws_lc_rs,fips,std
+# TEST WITHOUT `fips` [FIPS REMOVED FROM THIS FORK]
+cargo test -p portable-rustls --locked --no-default-features --features tls12,logging,aws_lc_rs,std
 cargo test -p portable-rustls --locked --no-default-features --features tls12,logging,ring,std
 
 # ensure both zlib and brotli are tested, irrespective of their order

--- a/bogo/Cargo.toml
+++ b/bogo/Cargo.toml
@@ -13,4 +13,4 @@ rustls-post-quantum = { path = "../rustls-post-quantum", optional = true }
 [features]
 default = []
 post-quantum = ["dep:rustls-post-quantum"]
-fips = ["rustls/fips"]
+# [FIPS REMOVED FROM THIS FORK] fips = ...

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -210,7 +210,9 @@ impl Options {
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum SelectedProvider {
     AwsLcRs,
-    #[cfg_attr(not(feature = "fips"), allow(dead_code))]
+    // [FIPS REMOVED FROM THIS FORK]
+    // #[cfg_attr(not(... "fips"), allow(...))]
+    #[allow(dead_code)]
     AwsLcRsFips,
     #[cfg_attr(not(feature = "post-quantum"), allow(dead_code))]
     PostQuantum,
@@ -224,8 +226,9 @@ impl SelectedProvider {
             .as_deref()
         {
             None | Some("aws-lc-rs") => Self::AwsLcRs,
-            #[cfg(feature = "fips")]
-            Some("aws-lc-rs-fips") => Self::AwsLcRsFips,
+            // [FIPS REMOVED FROM THIS FORK]
+            // #[cfg(... "fips")]
+            // Some("aws-lc-rs-fips") => ...
             #[cfg(feature = "post-quantum")]
             Some("post-quantum") => Self::PostQuantum,
             Some("ring") => Self::Ring,
@@ -1557,10 +1560,9 @@ pub fn main() {
             "-install-one-cert-compression-alg" => {
                 opts.install_cert_compression_algs = CompressionAlgs::One(args.remove(0).parse::<u16>().unwrap());
             }
-            #[cfg(feature = "fips")]
-            "-fips-202205" if opts.selected_provider == SelectedProvider::AwsLcRsFips => {
-                opts.provider = rustls::crypto::default_fips_provider();
-            }
+            // [FIPS REMOVED FROM THIS FORK]
+            // #[cfg(... "fips")]
+            // "-fips-202205" ...
             "-fips-202205" => {
                 println!("Not a FIPS build");
                 process::exit(BOGO_NACK);

--- a/rustls-bench/Cargo.toml
+++ b/rustls-bench/Cargo.toml
@@ -11,7 +11,7 @@ rustls-post-quantum = { path = "../rustls-post-quantum", optional = true }
 [features]
 default = []
 aws-lc-rs = ["rustls/aws-lc-rs"]
-fips = ["rustls/fips", "aws-lc-rs"]
+# [FIPS REMOVED FROM THIS FORK] fips = ...
 post-quantum = ["dep:rustls-post-quantum"]
 ring = ["rustls/ring"]
 

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -928,8 +928,9 @@ impl ResumptionParam {
 enum Provider {
     #[cfg(feature = "aws-lc-rs")]
     AwsLcRs,
-    #[cfg(all(feature = "aws-lc-rs", feature = "fips"))]
-    AwsLcRsFips,
+    // [FIPS REMOVED FROM THIS FORK]
+    // #[cfg(all(..., ... "fips"))]
+    // AwsLcRsFips,
     #[cfg(feature = "post-quantum")]
     PostQuantum,
     #[cfg(feature = "ring")]
@@ -943,8 +944,9 @@ impl Provider {
         match self {
             #[cfg(feature = "aws-lc-rs")]
             Self::AwsLcRs => rustls::crypto::aws_lc_rs::default_provider(),
-            #[cfg(all(feature = "aws-lc-rs", feature = "fips"))]
-            Self::AwsLcRsFips => rustls::crypto::default_fips_provider(),
+            // [FIPS REMOVED FROM THIS FORK]
+            // #[cfg(all(..., ... "fips"))]
+            // Self::AwsLcRsFips => ...
             #[cfg(feature = "post-quantum")]
             Self::PostQuantum => rustls_post_quantum::provider(),
             #[cfg(feature = "ring")]
@@ -957,8 +959,9 @@ impl Provider {
         match self {
             #[cfg(feature = "aws-lc-rs")]
             Self::AwsLcRs => rustls::crypto::aws_lc_rs::Ticketer::new(),
-            #[cfg(all(feature = "aws-lc-rs", feature = "fips"))]
-            Self::AwsLcRsFips => rustls::crypto::aws_lc_rs::Ticketer::new(),
+            // [FIPS REMOVED FROM THIS FORK]
+            // #[cfg(all(..., ... "fips"))]
+            // Self::AwsLcRsFips => ...
             #[cfg(feature = "post-quantum")]
             Self::PostQuantum => rustls::crypto::aws_lc_rs::Ticketer::new(),
             #[cfg(feature = "ring")]
@@ -994,8 +997,9 @@ impl Provider {
         #[cfg(feature = "aws-lc-rs")]
         available.push(Self::AwsLcRs);
 
-        #[cfg(all(feature = "aws-lc-rs", feature = "fips"))]
-        available.push(Self::AwsLcRsFips);
+        // [FIPS REMOVED FROM THIS FORK]
+        // #[cfg(all(..., ... "fips"))]
+        // available.push(...);
 
         #[cfg(feature = "post-quantum")]
         available.push(Self::PostQuantum);

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -22,7 +22,7 @@ aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
 aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
 custom-provider = []
-fips = ["aws_lc_rs", "aws-lc-rs?/fips"]
+# [FIPS REMOVED FROM THIS FORK] fips = ...
 logging = ["log"]
 prefer-post-quantum = ["aws_lc_rs"]
 read_buf = ["rustversion", "std"]
@@ -112,8 +112,8 @@ name = "unbuffered"
 path = "tests/runners/unbuffered.rs"
 
 [package.metadata.docs.rs]
-# all non-default features except fips (cannot build on docs.rs environment)
-features = ["read_buf", "ring"]
+# (CARGO DOC WITH ALL FEATURES IN THIS FORK)
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo_check_external_types]

--- a/rustls/src/client/builder.rs
+++ b/rustls/src/client/builder.rs
@@ -180,7 +180,7 @@ impl ConfigBuilder<ClientConfig, WantsClientCert> {
             enable_secret_extraction: false,
             enable_early_data: false,
             #[cfg(feature = "tls12")]
-            require_ems: cfg!(feature = "fips"),
+            require_ems: false, // [FIPS REMOVED FROM THIS FORK] cfg!(... "fips"),
             time_provider: self.time_provider,
             cert_compressors: compress::default_cert_compressors().to_vec(),
             cert_compression_cache: Arc::new(compress::CompressionCache::default()),

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -207,15 +207,21 @@ pub struct ClientConfig {
     /// If set to `true`, requires the server to support the extended
     /// master secret extraction method defined in [RFC 7627].
     ///
+    /// <!-- [FIPS REMOVED FROM THIS FORK]
     /// The default is `true` if the `fips` crate feature is enabled,
     /// `false` otherwise.
+    /// -- -->
     ///
+    /// <!-- [FIPS REMOVED FROM THIS FORK]
     /// It must be set to `true` to meet FIPS requirement mentioned in section
     /// **D.Q Transition of the TLS 1.2 KDF to Support the Extended Master
     /// Secret** from [FIPS 140-3 IG.pdf].
+    /// -- -->
     ///
     /// [RFC 7627]: https://datatracker.ietf.org/doc/html/rfc7627
+    /// <!-- [FIPS REMOVED FROM THIS FORK]
     /// [FIPS 140-3 IG.pdf]: https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf
+    /// -- -->
     #[cfg(feature = "tls12")]
     pub require_ems: bool,
 
@@ -351,9 +357,11 @@ impl ClientConfig {
     /// Return true if connections made with this `ClientConfig` will
     /// operate in FIPS mode.
     ///
+    /// <!-- [FIPS REMOVED FROM THIS FORK]
     /// This is different from [`CryptoProvider::fips()`]: [`CryptoProvider::fips()`]
     /// is concerned only with cryptography, whereas this _also_ covers TLS-level
     /// configuration that NIST recommends, as well as ECH HPKE suites if applicable.
+    /// -- -->
     pub fn fips(&self) -> bool {
         let mut is_fips = self.provider.fips();
 
@@ -745,9 +753,11 @@ mod connection {
 
         /// Return true if the connection was made with a `ClientConfig` that is FIPS compatible.
         ///
+        /// <!-- [FIPS REMOVED FROM THIS FORK]
         /// This is different from [`crate::crypto::CryptoProvider::fips()`]:
         /// it is concerned only with cryptography, whereas this _also_ covers TLS-level
         /// configuration that NIST recommends, as well as ECH HPKE suites if applicable.
+        /// -- -->
         pub fn fips(&self) -> bool {
             self.inner.core.common_state.fips
         }

--- a/rustls/src/crypto/aws_lc_rs/hpke.rs
+++ b/rustls/src/crypto/aws_lc_rs/hpke.rs
@@ -27,21 +27,21 @@ use crate::{Error, OtherError};
 pub static ALL_SUPPORTED_SUITES: &[&dyn Hpke] = &[
     DH_KEM_P256_HKDF_SHA256_AES_128,
     DH_KEM_P256_HKDF_SHA256_AES_256,
-    #[cfg(not(feature = "fips"))]
+    // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
     DH_KEM_P256_HKDF_SHA256_CHACHA20_POLY1305,
     DH_KEM_P384_HKDF_SHA384_AES_128,
     DH_KEM_P384_HKDF_SHA384_AES_256,
-    #[cfg(not(feature = "fips"))]
+    // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
     DH_KEM_P384_HKDF_SHA384_CHACHA20_POLY1305,
     DH_KEM_P521_HKDF_SHA512_AES_128,
     DH_KEM_P521_HKDF_SHA512_AES_256,
-    #[cfg(not(feature = "fips"))]
+    // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
     DH_KEM_P521_HKDF_SHA512_CHACHA20_POLY1305,
-    #[cfg(not(feature = "fips"))]
+    // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
     DH_KEM_X25519_HKDF_SHA256_AES_128,
-    #[cfg(not(feature = "fips"))]
+    // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
     DH_KEM_X25519_HKDF_SHA256_AES_256,
-    #[cfg(not(feature = "fips"))]
+    // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
     DH_KEM_X25519_HKDF_SHA256_CHACHA20_POLY1305,
 ];
 
@@ -1007,7 +1007,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "fips"))] // Ensure all supported suites are available to test.
+    // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))] // Ensure all supported suites are available to test.
     #[test]
     fn test_fips() {
         let testcases: &[(&dyn Hpke, bool)] = &[
@@ -1108,21 +1108,21 @@ mod rfc_tests {
     static TEST_SUITES: &[&dyn TestHpke] = &[
         DH_KEM_P256_HKDF_SHA256_AES_128,
         DH_KEM_P256_HKDF_SHA256_AES_256,
-        #[cfg(not(feature = "fips"))]
+        // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
         DH_KEM_P256_HKDF_SHA256_CHACHA20_POLY1305,
         DH_KEM_P384_HKDF_SHA384_AES_128,
         DH_KEM_P384_HKDF_SHA384_AES_256,
-        #[cfg(not(feature = "fips"))]
+        // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
         DH_KEM_P384_HKDF_SHA384_CHACHA20_POLY1305,
         DH_KEM_P521_HKDF_SHA512_AES_128,
         DH_KEM_P521_HKDF_SHA512_AES_256,
-        #[cfg(not(feature = "fips"))]
+        // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
         DH_KEM_P521_HKDF_SHA512_CHACHA20_POLY1305,
-        #[cfg(not(feature = "fips"))]
+        // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
         DH_KEM_X25519_HKDF_SHA256_AES_128,
-        #[cfg(not(feature = "fips"))]
+        // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
         DH_KEM_X25519_HKDF_SHA256_AES_256,
-        #[cfg(not(feature = "fips"))]
+        // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
         DH_KEM_X25519_HKDF_SHA256_CHACHA20_POLY1305,
     ];
 

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -50,15 +50,10 @@ pub fn default_provider() -> CryptoProvider {
 }
 
 fn default_kx_groups() -> Vec<&'static dyn SupportedKxGroup> {
-    #[cfg(feature = "fips")]
-    {
-        DEFAULT_KX_GROUPS
-            .iter()
-            .filter(|cs| cs.fips())
-            .copied()
-            .collect()
-    }
-    #[cfg(not(feature = "fips"))]
+    // [FIPS REMOVED FROM THIS FORK]
+    // #[cfg(... "fips")]
+    // ...
+    // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
     {
         DEFAULT_KX_GROUPS.to_vec()
     }
@@ -102,20 +97,24 @@ pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
     // TLS1.3 suites
     tls13::TLS13_AES_256_GCM_SHA384,
     tls13::TLS13_AES_128_GCM_SHA256,
-    #[cfg(not(feature = "fips"))]
+    // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
     tls13::TLS13_CHACHA20_POLY1305_SHA256,
     // TLS1.2 suites
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-    #[cfg(all(feature = "tls12", not(feature = "fips")))]
+    // [FIPS REMOVED FROM THIS FORK]
+    // #[cfg(all(..., not(... "fips")))]
+    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
     #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-    #[cfg(all(feature = "tls12", not(feature = "fips")))]
+    // [FIPS REMOVED FROM THIS FORK]
+    // #[cfg(all(..., not(... "fips")))]
+    #[cfg(feature = "tls12")]
     tls12::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
@@ -294,15 +293,12 @@ pub(super) fn unspecified_err(_e: aws_lc_rs::error::Unspecified) -> Error {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "fips")]
-    #[test]
-    fn default_suites_are_fips() {
-        assert!(super::DEFAULT_CIPHER_SUITES
-            .iter()
-            .all(|scs| scs.fips()));
-    }
+    // [FIPS REMOVED FROM THIS FORK]
+    // #[cfg(... "fips")]
+    // #[test]
+    // fn default_suites_are_fips() ...
 
-    #[cfg(not(feature = "fips"))]
+    // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))]
     #[test]
     fn default_suites() {
         assert_eq!(super::DEFAULT_CIPHER_SUITES, super::ALL_CIPHER_SUITES);

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -654,46 +654,11 @@ impl From<Vec<u8>> for SharedSecret {
     }
 }
 
-/// This function returns a [`CryptoProvider`] that uses
-/// FIPS140-3-approved cryptography.
-///
-/// Using this function expresses in your code that you require
-/// FIPS-approved cryptography, and will not compile if you make
-/// a mistake with cargo features.
-///
-/// See our [FIPS documentation](crate::manual::_06_fips) for
-/// more detail.
-///
-/// Install this as the process-default provider, like:
-///
-/// ```rust
-/// # #[cfg(feature = "fips")] {
-/// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
-/// rustls::crypto::default_fips_provider().install_default()
-///     .expect("default provider already set elsewhere");
-/// # }
-/// ```
-///
-/// You can also use this explicitly, like:
-///
-/// ```rust
-/// # #[cfg(feature = "fips")] {
-/// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
-/// # let root_store = rustls::RootCertStore::empty();
-/// let config = rustls::ClientConfig::builder_with_provider(
-///         rustls::crypto::default_fips_provider().into()
-///     )
-///     .with_safe_default_protocol_versions()
-///     .unwrap()
-///     .with_root_certificates(root_store)
-///     .with_no_client_auth();
-/// # }
-/// ```
-#[cfg(all(feature = "aws_lc_rs", any(feature = "fips", docsrs)))]
-#[cfg_attr(docsrs, doc(cfg(feature = "fips")))]
-pub fn default_fips_provider() -> CryptoProvider {
-    aws_lc_rs::default_provider()
-}
+// [FIPS REMOVED FROM THIS FORK]
+// /// This function returns a [`CryptoProvider`] that uses
+// /// FIPS140-3-approved cryptography.
+// ...
+// pub fn default_fips_provider() ...
 
 mod static_default {
     #[cfg(not(feature = "std"))]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -8,6 +8,9 @@
 //! * USE DEPENDENCY LIKE THIS IN `Cargo.toml`: `rustls = { package = "portable-rustls", ... }`
 //! * IMPORT AS USUAL FROM `rustls`: `use rustls;` OR `use rustls::...`
 //!
+//! ADDITIONAL NOTE: FIPS SUPPORT IS REMOVED FROM THIS FORK. THERE MAY BE SOME VESTIGES IN THE API,
+//! IMPLEMENTATION OR DOCUMENTATION BUT THIS DOES NOT IMPLY EXISTENCE OF FIPS SUPPORT IN ANY FORM.
+//!
 //! <!-- TODO(portable-rustls) UPDATE INFO FOR THIS FORK -->
 //! Rustls is a TLS library that aims to provide a good level of cryptographic security,
 //! requires no configuration to achieve that security, and provides no unsafe features or
@@ -309,12 +312,14 @@
 //!   use it as the default `CryptoProvider`, or provide it explicitly
 //!   when making a `ClientConfig` or `ServerConfig`.
 //!
+//! <!-- [FIPS REMOVED FROM THIS FORK]
 //! - `fips`: enable support for FIPS140-3-approved cryptography, via the [`aws-lc-rs`] crate.
 //!   This feature enables the `aws_lc_rs` crate feature, which makes the rustls crate depend
 //!   on [aws-lc-rs](https://github.com/aws/aws-lc-rs).  It also changes the default
 //!   for [`ServerConfig::require_ems`] and [`ClientConfig::require_ems`].
 //!
 //!   See [manual::_06_fips] for more details.
+//! -- -->
 //!
 //! - `prefer-post-quantum`: for the [`aws-lc-rs`]-backed provider, prioritizes post-quantum secure
 //!   key exchange by default (using X25519MLKEM768).  This feature merely alters the order

--- a/rustls/src/manual/fips.rs
+++ b/rustls/src/manual/fips.rs
@@ -1,3 +1,4 @@
+// [FIPS REMOVED FROM THIS FORK] ORPHANED MANUAL MODULE
 /*! # Using rustls with FIPS-approved cryptography
 
 To use FIPS-approved cryptography with rustls, you should take

--- a/rustls/src/manual/mod.rs
+++ b/rustls/src/manual/mod.rs
@@ -29,6 +29,7 @@ pub mod _04_features;
 #[path = "defaults.rs"]
 pub mod _05_defaults;
 
-/// This section provides guidance on using rustls with FIPS-approved cryptography.
-#[path = "fips.rs"]
-pub mod _06_fips;
+// [FIPS REMOVED FROM THIS FORK]
+// /// This section provides guidance on using rustls with FIPS-approved cryptography.
+// #[path = "fips.rs"]
+// pub mod _06_fips;

--- a/rustls/src/server/builder.rs
+++ b/rustls/src/server/builder.rs
@@ -139,7 +139,7 @@ impl ConfigBuilder<ServerConfig, WantsServerCert> {
             send_half_rtt_data: false,
             send_tls13_tickets: 2,
             #[cfg(feature = "tls12")]
-            require_ems: cfg!(feature = "fips"),
+            require_ems: false, // [FIPS REMOVED FROM THIS FORK] cfg!(... "fips"),
             time_provider: self.time_provider,
             cert_compressors: compress::default_cert_compressors().to_vec(),
             cert_compression_cache: Arc::new(compress::CompressionCache::default()),

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -345,15 +345,21 @@ pub struct ServerConfig {
     /// If set to `true`, requires the client to support the extended
     /// master secret extraction method defined in [RFC 7627].
     ///
+    /// <!-- [FIPS REMOVED FROM THIS FORK]
     /// The default is `true` if the "fips" crate feature is enabled,
     /// `false` otherwise.
+    /// -- -->
     ///
+    /// <!-- [FIPS REMOVED FROM THIS FORK]
     /// It must be set to `true` to meet FIPS requirement mentioned in section
     /// **D.Q Transition of the TLS 1.2 KDF to Support the Extended Master
     /// Secret** from [FIPS 140-3 IG.pdf].
+    /// -- -->
     ///
     /// [RFC 7627]: https://datatracker.ietf.org/doc/html/rfc7627
+    /// <!-- [FIPS REMOVED FROM THIS FORK]
     /// [FIPS 140-3 IG.pdf]: https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf
+    /// -- -->
     #[cfg(feature = "tls12")]
     pub require_ems: bool,
 
@@ -478,9 +484,11 @@ impl ServerConfig {
     /// Return `true` if connections made with this `ServerConfig` will
     /// operate in FIPS mode.
     ///
+    /// <!-- [FIPS REMOVED FROM THIS FORK]
     /// This is different from [`CryptoProvider::fips()`]: [`CryptoProvider::fips()`]
     /// is concerned only with cryptography, whereas this _also_ covers TLS-level
     /// configuration that NIST recommends.
+    /// -- -->
     pub fn fips(&self) -> bool {
         #[cfg(feature = "tls12")]
         {
@@ -662,9 +670,11 @@ mod connection {
 
         /// Return true if the connection was made with a `ServerConfig` that is FIPS compatible.
         ///
+        /// <!-- [FIPS REMOVED FROM THIS FORK]
         /// This is different from [`crate::crypto::CryptoProvider::fips()`]:
         /// it is concerned only with cryptography, whereas this _also_ covers TLS-level
         /// configuration that NIST recommends, as well as ECH HPKE suites if applicable.
+        /// -- -->
         pub fn fips(&self) -> bool {
             self.inner.core.common_state.fips
         }

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -6717,11 +6717,13 @@ fn test_secret_extraction_enabled() {
     for suite in [
         cipher_suite::TLS13_AES_128_GCM_SHA256,
         cipher_suite::TLS13_AES_256_GCM_SHA384,
-        #[cfg(not(feature = "fips"))]
+        // [FIPS REMOVED FROM THIS FORK]
+        // #[cfg(not(... "fips"))]
         cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
         cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
         cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-        #[cfg(not(feature = "fips"))]
+        // [FIPS REMOVED FROM THIS FORK]
+        // #[cfg(not(... "fips"))]
         cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
     ] {
         let version = suite.version();

--- a/rustls/tests/bogo.rs
+++ b/rustls/tests/bogo.rs
@@ -14,11 +14,10 @@ fn run_bogo_tests_aws_lc_rs() {
     run_bogo_tests("aws-lc-rs");
 }
 
-#[test]
-#[ignore]
-fn run_bogo_tests_aws_lc_rs_fips() {
-    run_bogo_tests("aws-lc-rs-fips");
-}
+// [FIPS REMOVED FROM THIS FORK]
+// #[test]
+// ...
+// fn run_bogo_tests_aws_lc_rs_fips() ...
 
 #[test]
 #[ignore]

--- a/rustls/tests/runners/macros.rs
+++ b/rustls/tests/runners/macros.rs
@@ -39,7 +39,9 @@ macro_rules! provider_aws_lc_rs {
         }
         #[allow(dead_code)]
         const fn provider_is_fips() -> bool {
-            cfg!(feature = "fips")
+            // [FIPS REMOVED FROM THIS FORK]
+            // cfg!(... "fips")
+            false
         }
     };
 }


### PR DESCRIPTION
__WHAT - DESCRIPTION__

```
- remove optional fips feature
- remove FIPS support
- update tests & test crates as needed
- update docs.rs config & CI to build doc with ALL features
- add & update some other CI comments related to this fork

---

PR ref: https://github.com/brody4hire/portable-rustls/pull/7
```

__WHY - MOTIVATION__

I would like to make some updates to the features supported in this fork:

- no features enabled by default, as proposed in PR: #1
- enforce updated `aws-lc-rs` feature name, as proposed in PR #5
- support log / logging feature under more limited circumstances, only for `std` or always for `std`, for example
- configure use of portable-atomic Arc & use of `critical-section` in multiple dependencies

These feature updates would require corresponding updates for docs.rs configuration to ensure that all features are documented in docs.rs, and docs CI would need to be updated as well. It looks like these updates are needed due to some issues between aws-lc-rs fips & docs.rs.

Removing fips support would simplify docs.rs configuration & docs testing with all features enabled.

This update may help simplify some other updates in the future.

Considering that this fork is intended to support small embedded devices, and it is not certified or even peer review, I would not expect any significant demand for this feature within the foreseeable future.

Lastly, I DO think that it should be pretty straightforward to add this feature back if needed someday in the future.

---

__OTHER NOTES__

- raised issue #11 regarding the generated documentation - took me a little while to better understand what is going on

---

__TODO ITEMS:__

- [x] update docs.rs configuration - should be able to simply configure docs.rs to build with all features enabled
- [x] update docs CI testing to mirror docs.rs configuration update - simply try building docs with all features enabled
- [x] update documentation as needed
- [x] resolve any main crate build issues
- [x] resolve any other build issues
- [x] update `.github/workflows/daily-tests.yml`
- [x] check that cargo hack build task is working in with all updates in daily tests CI action - manually enable daily tests action for `remove-fips-feature` branch in this page: https://github.com/brody4hire/portable-rustls/actions/workflows/daily-tests.yml
- [x] resolve any other issues in CI testing
- [x] check for any remaining `feature = "fips"` cfg items - should remove or comment these out
- [x] check for any remaining `fips` features in cargo TOML files - remove or comment out
- [x] resolve (or defer) any remaining XXX todo items in these updates
- [x] final review before merging
- [x] description above should be pasted into the commit message when merging, if not already done by rebasing