### PR TITLE
[portable-rustls] CI: daily feature powerset build on multiple platforms

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -133,19 +133,44 @@ jobs:
 
 
   feature-powerset:
-    name: Feature Powerset
-    runs-on: ubuntu-latest
+    # UPDATED TITLE IN THIS FORK
+    name: Feature Powerset - build
+    # FOR MORE FLEXIBLE FEATURE POWERSET CI CONFIGURATION IN THIS FORK
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          # FEATURE POWERSET ON MULTIPLE PLATFORMS IN THIS FORK
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        rust:
+          # MULTIPLE RUST VERSIONS FOR FUTURE CONSIDERATION IN THIS FORK
+          - stable
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      # FOR MORE FLEXIBLE FEATURE POWERSET CI CONFIGURATION IN THIS FORK
+      - name: Install ${{ matrix.rust }} toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
 
       - name: Install cargo hack
         uses: taiki-e/install-action@cargo-hack
+
+      # FOR MORE FLEXIBLE FEATURE POWERSET CI CONFIGURATION IN THIS FORK
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+
+      # FOR MORE FLEXIBLE FEATURE POWERSET CI CONFIGURATION IN THIS FORK
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v6
 
       - name: Check feature powerset
         run: >


### PR DESCRIPTION
__TODO__

- [x] check that cargo hack build task is working in daily tests CI action - manually trigger daily tests action for `brody-daily-ci-feature-powerset-on-multiple-platforms` branch in the following location & check CI results:
  - https://github.com/brody4hire/portable-rustls/actions/workflows/daily-tests.yml
- [x] update commit message to match title of this PR

NOTE: These updates include some additional installation steps for Windows. One of these steps is to install Ninja build as needed for fips, which is slated to be removed in other PR #7. I may decide to keep feature powerset build on Windows for future consideration given that CI build on Windows seems to be significantly slower.

It seems to me like CI build jobs are generally fasted on macOS.