### PR TITLE
[portable-rustls] RFC 7250 compliance update from upstream RUSTLS

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -135,12 +135,12 @@ jobs:
   feature-powerset:
     # UPDATED TITLE IN THIS FORK
     name: Feature Powerset - build
-    # FOR MORE FLEXIBLE FEATURE POWERSET CI CONFIGURATION IN THIS FORK
+    # FOR FEATURE POWERSET CI ON MULTIPLE PLATFORMS IN THIS FORK
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os:
-          # FEATURE POWERSET ON MULTIPLE PLATFORMS IN THIS FORK
+          # FOR FEATURE POWERSET CI ON MULTIPLE PLATFORMS IN THIS FORK
           - ubuntu-latest
           - macos-latest
           - windows-latest
@@ -153,7 +153,7 @@ jobs:
         with:
           persist-credentials: false
 
-      # FOR MORE FLEXIBLE FEATURE POWERSET CI CONFIGURATION IN THIS FORK
+      # FOR FEATURE POWERSET CI ON MULTIPLE PLATFORMS IN THIS FORK
       - name: Install ${{ matrix.rust }} toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -162,12 +162,12 @@ jobs:
       - name: Install cargo hack
         uses: taiki-e/install-action@cargo-hack
 
-      # FOR MORE FLEXIBLE FEATURE POWERSET CI CONFIGURATION IN THIS FORK
+      # FOR FEATURE POWERSET CI ON WINDOWS IN THIS FORK
       - name: Install NASM for aws-lc-rs on Windows
         if: runner.os == 'Windows'
         uses: ilammy/setup-nasm@v1
 
-      # FOR MORE FLEXIBLE FEATURE POWERSET CI CONFIGURATION IN THIS FORK
+      # FOR FEATURE POWERSET CI ON MULTIPLE PLATFORMS IN THIS FORK
       - name: Install ninja-build tool for aws-lc-fips-sys on Windows
         if: runner.os == 'Windows'
         uses: seanmiddleditch/gha-setup-ninja@v6

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -11,7 +11,7 @@ use crate::log::{debug, error, warn};
 use crate::msgs::alert::AlertMessagePayload;
 use crate::msgs::base::Payload;
 use crate::msgs::codec::Codec;
-use crate::msgs::enums::{AlertLevel, ExtensionType, KeyUpdateRequest};
+use crate::msgs::enums::{AlertLevel, KeyUpdateRequest};
 use crate::msgs::fragmenter::MessageFragmenter;
 use crate::msgs::handshake::{CertificateChain, HandshakeMessagePayload};
 use crate::msgs::message::{
@@ -24,7 +24,7 @@ use crate::suites::{PartiallyExtractedSecrets, SupportedCipherSuite};
 use crate::tls12::ConnectionSecrets;
 use crate::unbuffered::{EncryptError, InsufficientSizeError};
 use crate::vecbuf::ChunkVecBuffer;
-use crate::{quic, record_layer, PeerIncompatible};
+use crate::{quic, record_layer};
 
 /// Connection state common to both client and server connections.
 pub struct CommonState {
@@ -898,35 +898,6 @@ enum Limit {
     #[cfg(feature = "std")]
     Yes,
     No,
-}
-
-#[derive(Debug)]
-pub(super) struct RawKeyNegotiationParams {
-    pub(super) peer_supports_raw_key: bool,
-    pub(super) local_expects_raw_key: bool,
-    pub(super) extension_type: ExtensionType,
-}
-
-impl RawKeyNegotiationParams {
-    pub(super) fn validate_raw_key_negotiation(&self) -> RawKeyNegotationResult {
-        match (self.local_expects_raw_key, self.peer_supports_raw_key) {
-            (true, true) => RawKeyNegotationResult::Negotiated(self.extension_type),
-            (false, false) => RawKeyNegotationResult::NotNegotiated,
-            (true, false) => RawKeyNegotationResult::Err(Error::PeerIncompatible(
-                PeerIncompatible::IncorrectCertificateTypeExtension,
-            )),
-            (false, true) => RawKeyNegotationResult::Err(Error::PeerIncompatible(
-                PeerIncompatible::UnsolicitedCertificateTypeExtension,
-            )),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub(crate) enum RawKeyNegotationResult {
-    Negotiated(ExtensionType),
-    NotNegotiated,
-    Err(Error),
 }
 
 /// Tracking technically-allowed protocol actions

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -269,9 +269,9 @@ impl ExtensionProcessing {
             // XXX THIS CASE SEEMS TO BE NEVER TESTED - NOT IN MAIN CRATE TESTS & NOT IN `openssl-tests`
             (false, false, true) => panic!("XXX"),
             // XXX THIS CASE ONLY TRIGGERS FAILURE IN `openssl-tests` - DOES NOT TRIGGER FAILURE IN MAIN CRATE
-            // (false, true, true) => panic!("XXX"),
+            (false, true, true) => panic!("XXX"),
             // XXX FINISH WITH NO CERT TYPE EXTENSION IN THIS CASE - DOES NOT SEEM TO TRIGGER ANY TEST FAILURES
-            (false, true, true) => return Ok(()),
+            // (false, true, true) => return Ok(()),
             // XXX THIS UPDATE ALSO ALSO DOES NOT SEEM TO TRIGGER ANY TEST FAILURES:
             // (false, true, true) => Ok((extension_type, CertificateType::RawPublicKey)),
             (false, true, false) => Err(Error::PeerIncompatible(

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -271,9 +271,9 @@ impl ExtensionProcessing {
             // XXX THIS CASE ONLY TRIGGERS FAILURE IN `openssl-tests` - DOES NOT TRIGGER FAILURE IN MAIN CRATE
             // (false, true, true) => panic!("XXX"),
             // XXX FINISH WITH NO CERT TYPE EXTENSION IN THIS CASE - DOES NOT SEEM TO TRIGGER ANY TEST FAILURES
-            // (false, true, true) => return Ok(()),
+            (false, true, true) => return Ok(()),
             // XXX THIS UPDATE ALSO ALSO DOES NOT SEEM TO TRIGGER ANY TEST FAILURES:
-            (false, true, true) => Ok((extension_type, CertificateType::RawPublicKey)),
+            // (false, true, true) => Ok((extension_type, CertificateType::RawPublicKey)),
             (false, true, false) => Err(Error::PeerIncompatible(
                 PeerIncompatible::IncorrectCertificateTypeExtension,
             )),

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -269,9 +269,9 @@ impl ExtensionProcessing {
             // XXX THIS CASE SEEMS TO BE NEVER TESTED - NOT IN MAIN CRATE TESTS & NOT IN `openssl-tests`
             (false, false, true) => panic!("XXX"),
             // XXX THIS CASE ONLY TRIGGERS FAILURE IN `openssl-tests` - DOES NOT TRIGGER FAILURE IN MAIN CRATE
-            (false, true, true) => panic!("XXX"),
+            // (false, true, true) => panic!("XXX"),
             // XXX FINISH WITH NO CERT TYPE EXTENSION IN THIS CASE - DOES NOT SEEM TO TRIGGER ANY TEST FAILURES
-            // (false, true, true) => return Ok(()),
+            (false, true, true) => return Ok(()),
             // XXX THIS UPDATE ALSO ALSO DOES NOT SEEM TO TRIGGER ANY TEST FAILURES:
             // (false, true, true) => Ok((extension_type, CertificateType::RawPublicKey)),
             (false, true, false) => Err(Error::PeerIncompatible(

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -264,7 +264,16 @@ impl ExtensionProcessing {
             client_supports.contains(&CertificateType::X509),
         ) {
             (true, true, _) => Ok((extension_type, CertificateType::RawPublicKey)),
-            (false, _, true) => Ok((extension_type, CertificateType::X509)),
+            // XXX XXX TRY REPLACING THIS WITH FINER CASES BELOW
+            // (false, _, true) => Ok((extension_type, CertificateType::X509)),
+            // XXX THIS CASE SEEMS TO BE NEVER TESTED - NOT IN MAIN CRATE TESTS & NOT IN `openssl-tests`
+            (false, false, true) => panic!("XXX"),
+            // XXX THIS CASE ONLY TRIGGERS FAILURE IN `openssl-tests` - DOES NOT TRIGGER FAILURE IN MAIN CRATE
+            // (false, true, true) => panic!("XXX"),
+            // XXX FINISH WITH NO CERT TYPE EXTENSION IN THIS CASE - DOES NOT SEEM TO TRIGGER ANY TEST FAILURES
+            (false, true, true) => return Ok(()),
+            // XXX THIS UPDATE ALSO ALSO DOES NOT SEEM TO TRIGGER ANY TEST FAILURES:
+            // (false, true, true) => Ok((extension_type, CertificateType::RawPublicKey)),
             (false, true, false) => Err(Error::PeerIncompatible(
                 PeerIncompatible::IncorrectCertificateTypeExtension,
             )),

--- a/rustls/src/server/hs.rs
+++ b/rustls/src/server/hs.rs
@@ -271,9 +271,9 @@ impl ExtensionProcessing {
             // XXX THIS CASE ONLY TRIGGERS FAILURE IN `openssl-tests` - DOES NOT TRIGGER FAILURE IN MAIN CRATE
             // (false, true, true) => panic!("XXX"),
             // XXX FINISH WITH NO CERT TYPE EXTENSION IN THIS CASE - DOES NOT SEEM TO TRIGGER ANY TEST FAILURES
-            (false, true, true) => return Ok(()),
+            // (false, true, true) => return Ok(()),
             // XXX THIS UPDATE ALSO ALSO DOES NOT SEEM TO TRIGGER ANY TEST FAILURES:
-            // (false, true, true) => Ok((extension_type, CertificateType::RawPublicKey)),
+            (false, true, true) => Ok((extension_type, CertificateType::RawPublicKey)),
             (false, true, false) => Err(Error::PeerIncompatible(
                 PeerIncompatible::IncorrectCertificateTypeExtension,
             )),

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -128,7 +128,7 @@ mod test_raw_keys {
                     assert_eq!(
                         err,
                         ErrorFromPeer::Server(Error::PeerIncompatible(
-                            PeerIncompatible::UnsolicitedCertificateTypeExtension
+                            PeerIncompatible::IncorrectCertificateTypeExtension
                         ))
                     )
                 }
@@ -165,50 +165,49 @@ mod test_raw_keys {
     }
 
     #[test]
-    fn incorrectly_alter_client_hello() {
+    fn alter_client_hello() {
+        connect_with_altered_certificate_type_extension(
+            true,
+            Some(&vec![CertificateType::X509]),
+            None,
+            Err(ErrorFromPeer::Server(Error::PeerIncompatible(
+                PeerIncompatible::IncorrectCertificateTypeExtension,
+            ))),
+        );
+        connect_with_altered_certificate_type_extension(
+            true,
+            None,
+            Some(&vec![CertificateType::X509]),
+            Err(ErrorFromPeer::Server(Error::PeerIncompatible(
+                PeerIncompatible::IncorrectCertificateTypeExtension,
+            ))),
+        );
+    }
+
+    fn connect_with_altered_certificate_type_extension(
+        server_requires_raw_keys: bool,
+        server_cert_types: Option<&Vec<CertificateType>>,
+        client_cert_types: Option<&Vec<CertificateType>>,
+        expected_result: Result<(), ErrorFromPeer>,
+    ) {
         for kt in ALL_KEY_TYPES {
             let client_config = Arc::new(make_client_config(*kt));
-            let server_config_rpk = Arc::new(make_server_config_with_raw_key_support(*kt));
+            let server_config_rpk = match server_requires_raw_keys {
+                true => Arc::new(make_server_config_with_raw_key_support(*kt)),
+                false => Arc::new(make_server_config(*kt)),
+            };
 
             // Alter Client Hello client certificate extension
             let (client, server) = make_pair_for_arc_configs(&client_config, &server_config_rpk);
-            let server_cert_altered = do_handshake_altered(
+            let cert_altered = do_handshake_altered(
                 client,
                 |_: &mut Message| -> Altered { Altered::InPlace },
                 |msg: &mut Message| {
-                    alter_client_hello_message(msg, Some(&vec![CertificateType::X509]), None)
+                    alter_client_hello_message(msg, server_cert_types, client_cert_types)
                 },
                 server,
             );
-            match server_cert_altered {
-                Ok(_) => unreachable!("Expected error because server cert is altered"),
-                Err(err) => assert_eq!(
-                    err,
-                    ErrorFromPeer::Server(Error::PeerIncompatible(
-                        PeerIncompatible::IncorrectCertificateTypeExtension
-                    ))
-                ),
-            }
-
-            // Alter Server Hello server certificate extension
-            let (client, server) = make_pair_for_arc_configs(&client_config, &server_config_rpk);
-            let client_cert_altered = do_handshake_altered(
-                client,
-                |_: &mut Message| -> Altered { Altered::InPlace },
-                |msg: &mut Message| {
-                    alter_client_hello_message(msg, None, Some(&vec![CertificateType::X509]))
-                },
-                server,
-            );
-            match client_cert_altered {
-                Ok(_) => unreachable!("Expected error because server cert is altered"),
-                Err(err) => assert_eq!(
-                    err,
-                    ErrorFromPeer::Server(Error::PeerIncompatible(
-                        PeerIncompatible::IncorrectCertificateTypeExtension
-                    ))
-                ),
-            }
+            assert_eq!(cert_altered, expected_result)
         }
     }
 


### PR DESCRIPTION
(resolves #12)

__STATUS__

- As discussed in issue #12, I think this should be considered unstable until upstream RUSTLS makes another release tag. I would rather wait for the next RUSTLS release tag before merging into this fork.
- I think the unit testing needs to be improved, more details should be coming soon.

---

__TODO__

- [ ] review unit testing, as described here & in issue #12
- [ ] Check CI status before merging
- [ ] Manually trigger daily tests in CI on `brody-rustls-rfc-7250-compliance-update` branch in Actions page & check the results before merging
- [ ] Clean up merge commit message(s); I think the final merge commit should include `PR ref: ...` line with reference to this PR before pushing to the main `main-dev-2025-01` branch.

__RECOMMENDED MERGE STRATEGY__

I think this should be merged with a merge commit, NOT a squash merge or rebase merge. My idea is to simply push the updates with merge from upstream RUSTLS directly into the main (`main-dev-2025-01`) branch. It may make sense to use an additional merge commit, which I would only favor if any additional changes are needed after merging from upstream RUSTLS branch.