### PR TITLE
[portable-rustls] FIXUP: REMOVE FIPS FN API NOT SUPPORTED (etc.)

### DIFF
--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -284,11 +284,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_fips() {
-        // None of the rust-crypto backed hpke-rs suites should be considered FIPS approved.
-        assert!(ALL_SUPPORTED_SUITES
-            .iter()
-            .all(|suite| !suite.fips()));
-    }
+    // [FIPS REMOVED FROM THIS FORK]
+    // #[test]
+    // fn test_fips() ...
 }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -362,6 +362,7 @@ impl ClientConfig {
     /// is concerned only with cryptography, whereas this _also_ covers TLS-level
     /// configuration that NIST recommends, as well as ECH HPKE suites if applicable.
     /// -- -->
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     pub fn fips(&self) -> bool {
         let mut is_fips = self.provider.fips();
 
@@ -758,6 +759,7 @@ mod connection {
         /// it is concerned only with cryptography, whereas this _also_ covers TLS-level
         /// configuration that NIST recommends, as well as ECH HPKE suites if applicable.
         /// -- -->
+        #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
         pub fn fips(&self) -> bool {
             self.inner.core.common_state.fips
         }
@@ -822,7 +824,9 @@ impl ConnectionCore<ClientConnectionData> {
         common_state.set_max_fragment_size(config.max_fragment_size)?;
         common_state.protocol = proto;
         common_state.enable_secret_extraction = config.enable_secret_extraction;
-        common_state.fips = config.fips();
+        // [FIPS REMOVED FROM THIS FORK]
+        // common_state.fips = config.fips();
+
         let mut data = ClientConnectionData::new();
 
         let mut cx = hs::ClientContext {

--- a/rustls/src/client/ech.rs
+++ b/rustls/src/client/ech.rs
@@ -48,6 +48,7 @@ pub enum EchMode {
 
 impl EchMode {
     /// Returns true if the ECH mode will use a FIPS approved HPKE suite.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     pub fn fips(&self) -> bool {
         match self {
             Self::Enable(ech_config) => ech_config.suite.fips(),

--- a/rustls/src/common_state.rs
+++ b/rustls/src/common_state.rs
@@ -56,6 +56,7 @@ pub struct CommonState {
     pub(crate) enable_secret_extraction: bool,
     temper_counters: TemperCounters,
     pub(crate) refresh_traffic_keys_pending: bool,
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     pub(crate) fips: bool,
 }
 
@@ -87,6 +88,7 @@ impl CommonState {
             enable_secret_extraction: false,
             temper_counters: TemperCounters::default(),
             refresh_traffic_keys_pending: false,
+            #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
             fips: false,
         }
     }

--- a/rustls/src/crypto/aws_lc_rs/hpke.rs
+++ b/rustls/src/crypto/aws_lc_rs/hpke.rs
@@ -359,6 +359,7 @@ impl<const KEY_SIZE: usize, const KDF_SIZE: usize> Hpke for HpkeAwsLcRs<KEY_SIZE
         Ok(Box::new(Opener::new(self, enc, info, secret_key)?))
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         matches!(
             // We make a FIPS determination based on the suite's DH KEM and AEAD choice.
@@ -1008,6 +1009,7 @@ mod tests {
     }
 
     // [FIPS REMOVED FROM THIS FORK] #[cfg(not(... "fips"))] // Ensure all supported suites are available to test.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     #[test]
     fn test_fips() {
         let testcases: &[(&dyn Hpke, bool)] = &[

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -71,6 +71,7 @@ impl SecureRandom for AwsLcRs {
             .map_err(|_| GetRandomFailed)
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         fips()
     }
@@ -84,6 +85,7 @@ impl KeyProvider for AwsLcRs {
         sign::any_supported_type(&key_der)
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         fips()
     }
@@ -276,6 +278,7 @@ mod ring_shim {
 }
 
 /// Are we in FIPS mode?
+#[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
 pub(super) fn fips() -> bool {
     aws_lc_rs::try_fips_mode().is_ok()
 }

--- a/rustls/src/crypto/aws_lc_rs/pq/hybrid.rs
+++ b/rustls/src/crypto/aws_lc_rs/pq/hybrid.rs
@@ -68,6 +68,7 @@ impl SupportedKxGroup for Hybrid {
         self.name
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         // Behold! The Night Mare: SP800-56C rev 2:
         //

--- a/rustls/src/crypto/aws_lc_rs/pq/mlkem.rs
+++ b/rustls/src/crypto/aws_lc_rs/pq/mlkem.rs
@@ -50,6 +50,7 @@ impl SupportedKxGroup for MlKem768 {
         NamedGroup::MLKEM768
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         // AUDITORS:
         // At the time of writing, the ML-KEM implementation in AWS-LC-FIPS module 3.0

--- a/rustls/src/crypto/aws_lc_rs/tls12.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls12.rs
@@ -187,6 +187,7 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
         })
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }
@@ -237,6 +238,7 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
         })
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false // not FIPS approved
     }
@@ -459,6 +461,7 @@ impl Prf for Tls12Prf {
         Ok(())
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }

--- a/rustls/src/crypto/aws_lc_rs/tls13.rs
+++ b/rustls/src/crypto/aws_lc_rs/tls13.rs
@@ -117,6 +117,7 @@ impl Tls13AeadAlgorithm for Chacha20Poly1305Aead {
         Ok(ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv })
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false // not FIPS approved
     }
@@ -145,6 +146,7 @@ impl Tls13AeadAlgorithm for Aes256GcmAead {
         Ok(ConnectionTrafficSecrets::Aes256Gcm { key, iv })
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }
@@ -173,6 +175,7 @@ impl Tls13AeadAlgorithm for Aes128GcmAead {
         Ok(ConnectionTrafficSecrets::Aes128Gcm { key, iv })
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }
@@ -387,6 +390,7 @@ impl Hkdf for AwsLcHkdf {
         crypto::hmac::Tag::new(hmac::sign(&hmac::Key::new(self.1, key.as_ref()), message).as_ref())
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }

--- a/rustls/src/crypto/cipher.rs
+++ b/rustls/src/crypto/cipher.rs
@@ -35,6 +35,7 @@ pub trait Tls13AeadAlgorithm: Send + Sync {
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError>;
 
     /// Return `true` if this is backed by a FIPS-approved implementation.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }
@@ -81,6 +82,7 @@ pub trait Tls12AeadAlgorithm: Send + Sync + 'static {
     ) -> Result<ConnectionTrafficSecrets, UnsupportedOperationError>;
 
     /// Return `true` if this is backed by a FIPS-approved implementation.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }

--- a/rustls/src/crypto/hash.rs
+++ b/rustls/src/crypto/hash.rs
@@ -20,6 +20,7 @@ pub trait Hash: Send + Sync {
     fn algorithm(&self) -> HashAlgorithm;
 
     /// Return `true` if this is backed by a FIPS-approved implementation.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }

--- a/rustls/src/crypto/hmac.rs
+++ b/rustls/src/crypto/hmac.rs
@@ -14,6 +14,7 @@ pub trait Hmac: Send + Sync {
     fn hash_output_len(&self) -> usize;
 
     /// Return `true` if this is backed by a FIPS-approved implementation.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }

--- a/rustls/src/crypto/hpke.rs
+++ b/rustls/src/crypto/hpke.rs
@@ -79,6 +79,7 @@ pub trait Hpke: Debug + Send + Sync {
     fn generate_key_pair(&self) -> Result<(HpkePublicKey, HpkePrivateKey), Error>;
 
     /// Return whether the HPKE instance is FIPS compatible.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -63,7 +63,7 @@ pub use crate::suites::CipherSuiteCommon;
 ///
 /// - [`crypto::aws_lc_rs::default_provider`] (behind the optional `aws-lc-rs` crate feature):
 ///   This provider uses the [aws-lc-rs](https://github.com/aws/aws-lc-rs)
-///   crate.  The `fips` crate feature makes this option use FIPS140-3-approved cryptography.
+///   crate. <!-- FIPS REMOVED FROM THIS FORK] The `fips` crate feature makes this option use FIPS140-3-approved cryptography. -->
 /// - [`crypto::ring::default_provider`] (behind the optional `ring` crate feature):
 ///   This provider uses the [*ring*](https://github.com/briansmith/ring)
 ///   crate.
@@ -176,11 +176,13 @@ pub use crate::suites::CipherSuiteCommon;
 /// [rust-crypto]: https://github.com/rustcrypto
 /// [dalek-cryptography]: https://github.com/dalek-cryptography
 ///
+/// <!-- [FIPS REMOVED FROM THIS FORK]
 /// # FIPS-approved cryptography
 /// The `fips` crate feature enables use of the `aws-lc-rs` crate in FIPS mode.
 ///
 /// You can verify the configuration at runtime by checking
 /// [`ServerConfig::fips()`]/[`ClientConfig::fips()`] return `true`.
+/// - END [FIPS REMOVED FROM THIS FORK] -->
 #[derive(Debug, Clone)]
 pub struct CryptoProvider {
     /// List of supported ciphersuites, in preference order -- the first element
@@ -288,6 +290,7 @@ impl CryptoProvider {
     /// also TLS protocol-level recommendations made by NIST.  You should
     /// prefer to call [`ClientConfig::fips()`] or [`ServerConfig::fips()`]
     /// which take these into account.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     pub fn fips(&self) -> bool {
         let Self {
             cipher_suites,
@@ -319,6 +322,7 @@ pub trait SecureRandom: Send + Sync + Debug {
     fn fill(&self, buf: &mut [u8]) -> Result<(), GetRandomFailed>;
 
     /// Return `true` if this is backed by a FIPS-approved implementation.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }
@@ -349,6 +353,7 @@ pub trait KeyProvider: Send + Sync + Debug {
     ///
     /// If this returns `true`, that must be the case for all possible key types
     /// supported by [`KeyProvider::load_private_key()`].
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }
@@ -414,6 +419,7 @@ pub trait SupportedKxGroup: Send + Sync + Debug {
     fn name(&self) -> NamedGroup;
 
     /// Return `true` if this is backed by a FIPS-approved implementation.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }

--- a/rustls/src/crypto/ring/hash.rs
+++ b/rustls/src/crypto/ring/hash.rs
@@ -30,6 +30,7 @@ impl crypto::hash::Hash for Hash {
         self.1
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }

--- a/rustls/src/crypto/ring/hmac.rs
+++ b/rustls/src/crypto/ring/hmac.rs
@@ -21,6 +21,7 @@ impl crypto::hmac::Hmac for Hmac {
         self.0.digest_algorithm().output_len()
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }

--- a/rustls/src/crypto/ring/kx.rs
+++ b/rustls/src/crypto/ring/kx.rs
@@ -22,6 +22,7 @@ struct KxGroup {
     ///
     /// `SupportedKxGroup::fips()` is true if and only if the algorithm is allowed,
     /// _and_ the implementation is FIPS-validated.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fips_allowed: bool,
 
     /// aws-lc-rs 1.9 and later accepts more formats of public keys than
@@ -66,6 +67,7 @@ impl SupportedKxGroup for KxGroup {
         self.name
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         self.fips_allowed && super::fips()
     }
@@ -87,6 +89,7 @@ pub static X25519: &dyn SupportedKxGroup = &KxGroup {
     //  schemes (defined in RFC 7748) that use Curve25519 and Curve448, respectively,
     //  are not compliant to SP 800-56Arev3."
     // -- <https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS%20140-3%20IG.pdf>
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fips_allowed: false,
 
     pub_key_validator: |point: &[u8]| point.len() == 32,
@@ -96,6 +99,7 @@ pub static X25519: &dyn SupportedKxGroup = &KxGroup {
 pub static SECP256R1: &dyn SupportedKxGroup = &KxGroup {
     name: NamedGroup::secp256r1,
     agreement_algorithm: &agreement::ECDH_P256,
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fips_allowed: true,
     pub_key_validator: uncompressed_point,
 };
@@ -104,6 +108,7 @@ pub static SECP256R1: &dyn SupportedKxGroup = &KxGroup {
 pub static SECP384R1: &dyn SupportedKxGroup = &KxGroup {
     name: NamedGroup::secp384r1,
     agreement_algorithm: &agreement::ECDH_P384,
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fips_allowed: true,
     pub_key_validator: uncompressed_point,
 };

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -196,6 +196,7 @@ mod ring_shim {
     }
 }
 
+#[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
 pub(super) fn fips() -> bool {
     false
 }

--- a/rustls/src/crypto/ring/quic.rs
+++ b/rustls/src/crypto/ring/quic.rs
@@ -207,6 +207,7 @@ impl quic::Algorithm for KeyBuilder {
         self.packet_alg.key_len()
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }

--- a/rustls/src/crypto/ring/tls12.rs
+++ b/rustls/src/crypto/ring/tls12.rs
@@ -170,6 +170,7 @@ impl Tls12AeadAlgorithm for GcmAlgorithm {
         })
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }
@@ -220,6 +221,7 @@ impl Tls12AeadAlgorithm for ChaCha20Poly1305 {
         })
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false // not fips approved
     }

--- a/rustls/src/crypto/ring/tls13.rs
+++ b/rustls/src/crypto/ring/tls13.rs
@@ -104,6 +104,7 @@ impl Tls13AeadAlgorithm for Chacha20Poly1305Aead {
         Ok(ConnectionTrafficSecrets::Chacha20Poly1305 { key, iv })
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false // chacha20poly1305 not FIPS approved
     }
@@ -132,6 +133,7 @@ impl Tls13AeadAlgorithm for Aes256GcmAead {
         Ok(ConnectionTrafficSecrets::Aes256Gcm { key, iv })
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }
@@ -160,6 +162,7 @@ impl Tls13AeadAlgorithm for Aes128GcmAead {
         Ok(ConnectionTrafficSecrets::Aes128Gcm { key, iv })
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }
@@ -294,6 +297,7 @@ impl Hkdf for RingHkdf {
         crypto::hmac::Tag::new(hmac::sign(&hmac::Key::new(self.1, key.as_ref()), message).as_ref())
     }
 
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         super::fips()
     }

--- a/rustls/src/crypto/tls12.rs
+++ b/rustls/src/crypto/tls12.rs
@@ -65,6 +65,7 @@ pub trait Prf: Send + Sync {
     fn for_secret(&self, output: &mut [u8], secret: &[u8], label: &[u8], seed: &[u8]);
 
     /// Return `true` if this is backed by a FIPS-approved implementation.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }

--- a/rustls/src/crypto/tls13.rs
+++ b/rustls/src/crypto/tls13.rs
@@ -177,6 +177,7 @@ pub trait Hkdf: Send + Sync {
     fn hmac_sign(&self, key: &OkmBlock, message: &[u8]) -> hmac::Tag;
 
     /// Return `true` if this is backed by a FIPS-approved implementation.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }

--- a/rustls/src/quic.rs
+++ b/rustls/src/quic.rs
@@ -619,6 +619,7 @@ pub trait Algorithm: Send + Sync {
     fn aead_key_len(&self) -> usize;
 
     /// Whether this algorithm is FIPS-approved.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     fn fips(&self) -> bool {
         false
     }

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -489,6 +489,7 @@ impl ServerConfig {
     /// is concerned only with cryptography, whereas this _also_ covers TLS-level
     /// configuration that NIST recommends.
     /// -- -->
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     pub fn fips(&self) -> bool {
         #[cfg(feature = "tls12")]
         {
@@ -675,6 +676,7 @@ mod connection {
         /// it is concerned only with cryptography, whereas this _also_ covers TLS-level
         /// configuration that NIST recommends, as well as ECH HPKE suites if applicable.
         /// -- -->
+        #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
         pub fn fips(&self) -> bool {
             self.inner.core.common_state.fips
         }
@@ -1130,7 +1132,9 @@ impl ConnectionCore<ServerConnectionData> {
         let mut common = CommonState::new(Side::Server);
         common.set_max_fragment_size(config.max_fragment_size)?;
         common.enable_secret_extraction = config.enable_secret_extraction;
-        common.fips = config.fips();
+        // [FIPS REMOVED FROM THIS FORK]
+        // common.fips = config.fips();
+
         Ok(Self::new(
             Box::new(hs::ExpectClientHello::new(config, extra_exts)),
             ServerConnectionData::default(),

--- a/rustls/src/suites.rs
+++ b/rustls/src/suites.rs
@@ -53,6 +53,7 @@ impl CipherSuiteCommon {
     /// Return `true` if this is backed by a FIPS-approved implementation.
     ///
     /// This means all the constituent parts that do cryptography return `true` for `fips()`.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     pub fn fips(&self) -> bool {
         self.hash_provider.fips()
     }
@@ -136,6 +137,7 @@ impl SupportedCipherSuite {
     }
 
     /// Return `true` if this is backed by a FIPS-approved implementation.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     pub fn fips(&self) -> bool {
         match self {
             #[cfg(feature = "tls12")]

--- a/rustls/src/tls12/mod.rs
+++ b/rustls/src/tls12/mod.rs
@@ -66,6 +66,7 @@ impl Tls12CipherSuite {
     /// Return `true` if this is backed by a FIPS-approved implementation.
     ///
     /// This means all the constituent parts that do cryptography return `true` for `fips()`.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     pub fn fips(&self) -> bool {
         self.common.fips() && self.prf_provider.fips() && self.aead_alg.fips()
     }

--- a/rustls/src/tls13/mod.rs
+++ b/rustls/src/tls13/mod.rs
@@ -45,6 +45,7 @@ impl Tls13CipherSuite {
     /// Return `true` if this is backed by a FIPS-approved implementation.
     ///
     /// This means all the constituent parts that do cryptography return `true` for `fips()`.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     pub fn fips(&self) -> bool {
         let Self {
             common,

--- a/rustls/src/webpki/verify.rs
+++ b/rustls/src/webpki/verify.rs
@@ -104,6 +104,7 @@ impl WebPkiSupportedAlgorithms {
     }
 
     /// Return `true` if all cryptography is FIPS-approved.
+    #[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
     pub fn fips(&self) -> bool {
         self.all.iter().all(|alg| alg.fips())
             && self

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -1,6 +1,8 @@
 //! Assorted public API tests.
 
 #![allow(clippy::duplicate_mod)]
+// ALLOW CFG ITEMS such as `unstable_api_not_supported` IN THIS FORK
+#![allow(unexpected_cfgs)]
 
 use std::fmt::Debug;
 use std::io::{self, BufRead, IoSlice, Read, Write};
@@ -23,6 +25,7 @@ use rustls::internal::msgs::handshake::{
 };
 use rustls::internal::msgs::message::{Message, MessagePayload, PlainMessage};
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
+#[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
 #[cfg(feature = "aws_lc_rs")]
 use rustls::{
     client::{EchConfig, EchGreaseConfig, EchMode},
@@ -7196,6 +7199,7 @@ fn test_client_removes_tls12_session_if_server_sends_undecryptable_first_message
     ));
 }
 
+#[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
 #[test]
 fn test_client_fips_service_indicator() {
     assert_eq!(
@@ -7204,6 +7208,7 @@ fn test_client_fips_service_indicator() {
     );
 }
 
+#[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
 #[test]
 fn test_server_fips_service_indicator() {
     assert_eq!(
@@ -7212,6 +7217,7 @@ fn test_server_fips_service_indicator() {
     );
 }
 
+#[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
 #[test]
 fn test_connection_fips_service_indicator() {
     let client_config = Arc::new(make_client_config(KeyType::Rsa2048));
@@ -7223,6 +7229,7 @@ fn test_connection_fips_service_indicator() {
     assert_eq!(server_config.fips(), conn_pair.1.fips());
 }
 
+#[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
 #[test]
 fn test_client_fips_service_indicator_includes_require_ems() {
     if !provider_is_fips() {
@@ -7235,6 +7242,7 @@ fn test_client_fips_service_indicator_includes_require_ems() {
     assert!(!client_config.fips());
 }
 
+#[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
 #[test]
 fn test_server_fips_service_indicator_includes_require_ems() {
     if !provider_is_fips() {
@@ -7247,6 +7255,7 @@ fn test_server_fips_service_indicator_includes_require_ems() {
     assert!(!server_config.fips());
 }
 
+#[cfg(unstable_api_not_supported)] // [FIPS REMOVED FROM THIS FORK]
 #[cfg(feature = "aws_lc_rs")]
 #[test]
 fn test_client_fips_service_indicator_includes_ech_hpke_suite() {


### PR DESCRIPTION
__TITLE & DESCRIPTION for commit message__

```
[portable-rustls] FIXUP: REMOVE FIPS FN API NOT SUPPORTED (etc.)

- use `unstable_api_not_supported` cfg to avoid building & documenting with unsupported FIPS FNs
- comment FIPS-related documentation out of a couple places

---

PR ref: https://github.com/brody4hire/portable-rustls/pull/30
```

__TODO__

- [x] resolve XXX / TODO items in these updates - or defer as may be needed
- [x] check CI build status - should ideally try daily build from actions tab on this branch & check that status as well
- [x] update description for commit message with PR ref & some more contents
- [x] rebase with clean commit title & message with above description