### PR TITLE
DRAFT RFC: remove Arc from default crypto provider API - DO NOT MERGE

### DIFF
--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -302,8 +302,9 @@ impl ClientConfig {
         // Safety assumptions:
         // 1. that the provider has been installed (explicitly or implicitly)
         // 2. that the process-level default provider is usable with the supplied protocol versions.
-        Self::builder_with_provider(Arc::clone(
-            CryptoProvider::get_default_or_install_from_crate_features(),
+        // XXX TODO NOTE & DOCUMENT: THIS MAKES A FULL CLONE OF crypto::CryptoProvider
+        Self::builder_with_provider(Arc::from(
+            CryptoProvider::get_default_or_install_from_crate_features().clone(),
         ))
         .with_protocol_versions(versions)
         .unwrap()

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -225,14 +225,14 @@ impl CryptoProvider {
     /// Call this early in your process to configure which provider is used for
     /// the provider.  The configuration should happen before any use of
     /// [`ClientConfig::builder()`] or [`ServerConfig::builder()`].
-    pub fn install_default(self) -> Result<(), Arc<Self>> {
+    pub fn install_default(self) -> Result<(), Box<Self>> {
         static_default::install_default(self)
     }
 
     /// Returns the default `CryptoProvider` for this process.
     ///
     /// This will be `None` if no default has been set yet.
-    pub fn get_default() -> Option<&'static Arc<Self>> {
+    pub fn get_default() -> Option<&'static Box<Self>> {
         static_default::get_default()
     }
 
@@ -241,7 +241,7 @@ impl CryptoProvider {
     /// - gets the pre-installed default, or
     /// - installs one `from_crate_features()`, or else
     /// - panics about the need to call [`CryptoProvider::install_default()`]
-    pub(crate) fn get_default_or_install_from_crate_features() -> &'static Arc<Self> {
+    pub(crate) fn get_default_or_install_from_crate_features() -> &'static Box<Self> {
         if let Some(provider) = Self::get_default() {
             return provider;
         }
@@ -661,7 +661,6 @@ impl From<Vec<u8>> for SharedSecret {
 // pub fn default_fips_provider() ...
 
 mod static_default {
-    #[cfg(not(feature = "std"))]
     use alloc::boxed::Box;
     #[cfg(feature = "std")]
     use std::sync::OnceLock;
@@ -670,32 +669,31 @@ mod static_default {
     use once_cell::race::OnceBox;
 
     use super::CryptoProvider;
-    use crate::sync::Arc;
 
     #[cfg(feature = "std")]
     pub(crate) fn install_default(
         default_provider: CryptoProvider,
-    ) -> Result<(), Arc<CryptoProvider>> {
-        PROCESS_DEFAULT_PROVIDER.set(Arc::new(default_provider))
+    ) -> Result<(), Box<CryptoProvider>> {
+        PROCESS_DEFAULT_PROVIDER.set(Box::new(default_provider))
     }
 
     #[cfg(not(feature = "std"))]
     pub(crate) fn install_default(
         default_provider: CryptoProvider,
-    ) -> Result<(), Arc<CryptoProvider>> {
+    ) -> Result<(), Box<CryptoProvider>> {
         PROCESS_DEFAULT_PROVIDER
-            .set(Box::new(Arc::new(default_provider)))
+            .set(Box::new(Box::new(default_provider)))
             .map_err(|e| *e)
     }
 
-    pub(crate) fn get_default() -> Option<&'static Arc<CryptoProvider>> {
+    pub(crate) fn get_default() -> Option<&'static Box<CryptoProvider>> {
         PROCESS_DEFAULT_PROVIDER.get()
     }
 
     #[cfg(feature = "std")]
-    static PROCESS_DEFAULT_PROVIDER: OnceLock<Arc<CryptoProvider>> = OnceLock::new();
+    static PROCESS_DEFAULT_PROVIDER: OnceLock<Box<CryptoProvider>> = OnceLock::new();
     #[cfg(not(feature = "std"))]
-    static PROCESS_DEFAULT_PROVIDER: OnceBox<Arc<CryptoProvider>> = OnceBox::new();
+    static PROCESS_DEFAULT_PROVIDER: OnceBox<Box<CryptoProvider>> = OnceBox::new();
 }
 
 #[cfg(test)]

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -232,7 +232,7 @@ impl CryptoProvider {
     /// Returns the default `CryptoProvider` for this process.
     ///
     /// This will be `None` if no default has been set yet.
-    pub fn get_default() -> Option<&'static Box<Self>> {
+    pub fn get_default() -> Option<&'static Self> {
         static_default::get_default()
     }
 
@@ -241,7 +241,7 @@ impl CryptoProvider {
     /// - gets the pre-installed default, or
     /// - installs one `from_crate_features()`, or else
     /// - panics about the need to call [`CryptoProvider::install_default()`]
-    pub(crate) fn get_default_or_install_from_crate_features() -> &'static Box<Self> {
+    pub(crate) fn get_default_or_install_from_crate_features() -> &'static Self {
         if let Some(provider) = Self::get_default() {
             return provider;
         }
@@ -686,8 +686,10 @@ mod static_default {
             .map_err(|e| *e)
     }
 
-    pub(crate) fn get_default() -> Option<&'static Box<CryptoProvider>> {
-        PROCESS_DEFAULT_PROVIDER.get()
+    pub(crate) fn get_default() -> Option<&'static CryptoProvider> {
+        PROCESS_DEFAULT_PROVIDER
+            .get()
+            .map(|v| &**v)
     }
 
     #[cfg(feature = "std")]

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -428,8 +428,9 @@ impl ServerConfig {
         // Safety assumptions:
         // 1. that the provider has been installed (explicitly or implicitly)
         // 2. that the process-level default provider is usable with the supplied protocol versions.
-        Self::builder_with_provider(Arc::clone(
-            CryptoProvider::get_default_or_install_from_crate_features(),
+        // XXX TODO NOTE & DOCUMENT: THIS MAKES A FULL CLONE OF crypto::CryptoProvider
+        Self::builder_with_provider(Arc::from(
+            CryptoProvider::get_default_or_install_from_crate_features().clone(),
         ))
         .with_protocol_versions(versions)
         .unwrap()

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -276,9 +276,10 @@ impl WebPkiClientVerifier {
     ///
     /// For more information, see the [`ClientCertVerifierBuilder`] documentation.
     pub fn builder(roots: Arc<RootCertStore>) -> ClientCertVerifierBuilder {
-        Self::builder_with_provider(
+        ClientCertVerifierBuilder::new(
             roots,
-            Arc::clone(CryptoProvider::get_default_or_install_from_crate_features()),
+            CryptoProvider::get_default_or_install_from_crate_features()
+                .signature_verification_algorithms,
         )
     }
 

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -151,9 +151,10 @@ impl WebPkiServerVerifier {
     ///
     /// For more information, see the [`ServerCertVerifierBuilder`] documentation.
     pub fn builder(roots: Arc<RootCertStore>) -> ServerCertVerifierBuilder {
-        Self::builder_with_provider(
+        ServerCertVerifierBuilder::new(
             roots,
-            Arc::clone(CryptoProvider::get_default_or_install_from_crate_features()),
+            CryptoProvider::get_default_or_install_from_crate_features()
+                .signature_verification_algorithms,
         )
     }
 


### PR DESCRIPTION
This is a DRAFT PROPOSAL to remove use of `Arc` from the default provider API functions in `crypto::CryptoProvider`.

This would be a first step towards switching from Arc to Rc as discussed in issue #29 and is intended to target a different fork (`embedded-rustls`, for example).

As a side point, I think it would be ideal if we could transition RUSTLS in general to switch from using Arc to using Box containers. I would love to investigate this further when I get a chance, someday.

---

__TODO__

- [ ] check CI status
- [ ] Document KNOWN LIMITATION that this would involve FULL CLONE of `crypto::CryptoProvider` object under certain circumstances. This does not seem to apply for no-std, may need further investigation to understand this.
- [ ] resolve or defer remaining XXX todo items
- [ ] rebase with clean commit message with a little more info & reference to this PR *if merged into this fork*