### PR TITLE
DRAFT RFC: make default crypto provider functionality optional for no-std - DO NOT MERGE

### DIFF
--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -21,6 +21,9 @@ aws-lc-rs = ["aws_lc_rs"] # ALIAS - FAVORED OVER `aws_lc_rs` FEATURE NAME IN THI
 aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
 custom-provider = []
+# XXX TODO UPDATE TESTING & DOCUMENTATION
+# XXX TODO ENSURE THIS SHOWS UP IN GENERATED DOCUMENTATION
+default-provider = []
 # [FIPS REMOVED FROM THIS FORK] fips = ...
 logging = ["log"]
 prefer-post-quantum = ["aws-lc-rs"]

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -225,6 +225,7 @@ impl CryptoProvider {
     /// Call this early in your process to configure which provider is used for
     /// the provider.  The configuration should happen before any use of
     /// [`ClientConfig::builder()`] or [`ServerConfig::builder()`].
+    #[cfg(any(feature = "default-provider", feature = "std"))]
     pub fn install_default(self) -> Result<(), Arc<Self>> {
         static_default::install_default(self)
     }
@@ -232,6 +233,7 @@ impl CryptoProvider {
     /// Returns the default `CryptoProvider` for this process.
     ///
     /// This will be `None` if no default has been set yet.
+    #[cfg(any(feature = "default-provider", feature = "std"))]
     pub fn get_default() -> Option<&'static Arc<Self>> {
         static_default::get_default()
     }
@@ -241,6 +243,7 @@ impl CryptoProvider {
     /// - gets the pre-installed default, or
     /// - installs one `from_crate_features()`, or else
     /// - panics about the need to call [`CryptoProvider::install_default()`]
+    #[cfg(any(feature = "default-provider", feature = "std"))]
     pub(crate) fn get_default_or_install_from_crate_features() -> &'static Arc<Self> {
         if let Some(provider) = Self::get_default() {
             return provider;
@@ -259,6 +262,7 @@ impl CryptoProvider {
     /// providers), or specify no providers, or the feature `custom-provider` is activated.
     /// In all cases the application should explicitly specify the provider to use
     /// with [`CryptoProvider::install_default`].
+    #[cfg(any(feature = "default-provider", feature = "std"))]
     fn from_crate_features() -> Option<Self> {
         #[cfg(all(
             feature = "ring",
@@ -660,6 +664,7 @@ impl From<Vec<u8>> for SharedSecret {
 // ...
 // pub fn default_fips_provider() ...
 
+#[cfg(any(feature = "default-provider", feature = "std"))]
 mod static_default {
     #[cfg(not(feature = "std"))]
     use alloc::boxed::Box;

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -275,6 +275,7 @@ impl WebPkiClientVerifier {
     /// Use [`Self::builder_with_provider`] if you wish to specify an explicit provider.
     ///
     /// For more information, see the [`ClientCertVerifierBuilder`] documentation.
+    #[cfg(any(feature = "default-provider", feature = "std"))]
     pub fn builder(roots: Arc<RootCertStore>) -> ClientCertVerifierBuilder {
         Self::builder_with_provider(
             roots,

--- a/rustls/src/webpki/server_verifier.rs
+++ b/rustls/src/webpki/server_verifier.rs
@@ -150,6 +150,7 @@ impl WebPkiServerVerifier {
     /// Use [`Self::builder_with_provider`] if you wish to specify an explicit provider.
     ///
     /// For more information, see the [`ServerCertVerifierBuilder`] documentation.
+    #[cfg(any(feature = "default-provider", feature = "std"))]
     pub fn builder(roots: Arc<RootCertStore>) -> ServerCertVerifierBuilder {
         Self::builder_with_provider(
             roots,


### PR DESCRIPTION
use `default-provider` feature to make default crypto provider functionality optional for no-std

This is intended as an improvement for switch to Rc in another fork such as `embedded-rustls`, as discussed in issue #29.

I have also started a daily test run in CI to check `cargo hack build` results with this new feature added: https://github.com/brody4hire/portable-rustls/actions/runs/13418975190