### PR TITLE
DRAFT RFC: drop support for some features with help from cfg options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: cargo build (debug; default features)
         run: cargo build --locked
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       # N/A [FIPS REMOVED FROM THIS FORK]: nb. feature sets that include "fips" ...
       # nb. "--all-targets" does not include doctests
@@ -211,6 +213,7 @@ jobs:
         run: cargo build --locked --no-default-features --features hashbrown --target ${{ env.NO_STD_BUILD_TARGET }}
         working-directory: rustls
         env:
+          # XXX TBD XXX
           RUSTFLAGS: --cfg hashbrown_cfg_not_supported
 
       # NOTE: no features are enabled by default on main crate in this fork
@@ -232,7 +235,7 @@ jobs:
 
       - name: cargo test (debug; no default features; aws-lc-rs,tls12)
         # (KEEPING --no-default-features which has no effect on main crate in this fork)
-        run: cargo test --no-default-features --features aws_lc_rs,tls12,std
+        run: cargo test --no-default-features --features include-extra-cfg-dependencies,tls12,std
         working-directory: rustls
         env:
           RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
@@ -324,7 +327,10 @@ jobs:
         run: cargo run -p rustls-bench --profile=bench --locked --features ring -- --multiplier 0.1
 
       - name: Smoke-test benchmark program (aws-lc-rs)
-        run: cargo run -p rustls-bench --profile=bench --locked --features aws-lc-rs -- --multiplier 0.1
+        # XXX XXX
+        run: cargo run -p rustls-bench --profile=bench --locked --features include-extra-cfg-dependencies -- --multiplier 0.1
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       # [FIPS REMOVED FROM THIS FORK]
       # - name: Smoke-test benchmark program (fips)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   MAIN_CRATE: portable-rustls
+  # XXX TBD DEFINE PER UNSUPPORTED CFG FEATURE - ??? ??? ???
   ALL_UNSUPPORTED_CFG: --cfg hashbrown_cfg_not_supported --cfg cfg_aws_lc_rs_not_supported
 
 concurrency:
@@ -94,9 +95,11 @@ jobs:
           RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       - name: cargo test (debug; aws-lc-rs)
-        run: cargo test --no-default-features --features aws_lc_rs,tls12,read_buf,logging,std --all-targets
+        run: cargo test --no-default-features --features tls12,read_buf,logging,std --all-targets
         env:
           RUST_BACKTRACE: 1
+          # XXX XXX ONLY KEEP UNSUPPORTED CFG for aws-lc-rs - ???
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       # [FIPS REMOVED FROM THIS FORK]
       # - name: cargo test (release; fips)
@@ -238,6 +241,7 @@ jobs:
         run: cargo test --no-default-features --features include-extra-cfg-dependencies,tls12,std
         working-directory: rustls
         env:
+          # XXX XXX ONLY KEEP UNSUPPORTED CFG for aws-lc-rs - ???
           RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       # [FIPS REMOVED FROM THIS FORK]
@@ -252,6 +256,8 @@ jobs:
   bogo:
     name: BoGo test suite
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -330,6 +336,7 @@ jobs:
         # XXX XXX
         run: cargo run -p rustls-bench --profile=bench --locked --features include-extra-cfg-dependencies -- --multiplier 0.1
         env:
+          # XXX XXX ONLY KEEP UNSUPPORTED CFG for aws-lc-rs - ???
           RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       # [FIPS REMOVED FROM THIS FORK]
@@ -373,6 +380,7 @@ jobs:
     env:
       # Favor CI testing on Rust nightly in this fork
       RUST_VERSION: nightly
+      RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -471,6 +479,8 @@ jobs:
 
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
   format:
     name: Format

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   MAIN_CRATE: portable-rustls
+  ALL_UNSUPPORTED_CFG: --cfg hashbrown_cfg_not_supported --cfg cfg_aws_lc_rs_not_supported
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -80,6 +81,7 @@ jobs:
         run: cargo test --release --locked --all-features --all-targets
         env:
           RUST_BACKTRACE: 1
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       # nb. this is separate since `--doc` option cannot be combined with other target option(s) ref:
       # - https://doc.rust-lang.org/cargo/commands/cargo-test.html
@@ -87,6 +89,7 @@ jobs:
         run: cargo test --release --locked --all-features --doc
         env:
           RUST_BACKTRACE: 1
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       - name: cargo test (debug; aws-lc-rs)
         run: cargo test --no-default-features --features aws_lc_rs,tls12,read_buf,logging,std --all-targets
@@ -105,15 +108,23 @@ jobs:
 
       - name: cargo test (debug; rustls-provider-example; all features)
         run: cargo test --all-features -p rustls-provider-example
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       - name: cargo build (debug; rustls-provider-test)
         run: cargo build --locked -p rustls-provider-test
 
       - name: cargo test (debug; rustls-provider-test; all features)
         run: cargo test --all-features -p rustls-provider-test
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
+      # XXX TBD ??? ???
       - name: cargo package --all-features -p ${{ env.MAIN_CRATE }}
         run: cargo package --all-features -p ${{ env.MAIN_CRATE }}
+        env:
+          # XXX TBD ??? ???
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
   msrv:
     # NOTE: MSRV - Rust nightly is covered by multiple jobs in portable-rustls-ci-build.yml
@@ -131,12 +142,16 @@ jobs:
 
       # zlib-rs is optional and requires a later MSRV
       - run: cargo check --locked --lib $(admin/all-features-except zlib ${{ env.MAIN_CRATE }}) -p ${{ env.MAIN_CRATE }}
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.75"
 
       - run: cargo check --locked --lib --all-features -p ${{ env.MAIN_CRATE }}
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
   features:
     name: Features
@@ -219,6 +234,8 @@ jobs:
         # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo test --no-default-features --features aws_lc_rs,tls12,std
         working-directory: rustls
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
       # [FIPS REMOVED FROM THIS FORK]
       # - name: cargo test (debug; no default features; fips,tls12)
@@ -316,7 +333,7 @@ jobs:
       - name: Run micro-benchmarks
         run: cargo bench --locked --all-features
         env:
-          RUSTFLAGS: --cfg=bench
+          RUSTFLAGS: --cfg=bench ${{ env.ALL_UNSUPPORTED_CFG }}
 
   docs:
     name: Check for documentation errors
@@ -340,6 +357,8 @@ jobs:
           cargo build --locked --all-features
           ./admin/pull-readme
           git diff --exit-code
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
   coverage:
     name: Measure coverage
@@ -512,6 +531,8 @@ jobs:
       - run: ./admin/clippy -- --deny warnings --allow clippy::disallowed_types
       # - Keep the main crate free of all warnings... FOR ALL FEATURES IN MAIN CRATE
       - run: cargo clippy -p ${{ env.MAIN_CRATE }} --all-features -- --deny warnings
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
   clippy-nightly:
     name: Clippy - Rust nightly
@@ -536,6 +557,8 @@ jobs:
       - run: ./admin/clippy -- --deny warnings --allow clippy::disallowed_types
       # DENY ALL WARNINGS FROM RUST NIGHTLY CLIPPY FOR ALL FEATURES IN MAIN CRATE in this fork
       - run: cargo clippy -p ${{ env.MAIN_CRATE }} --all-features -- --deny warnings
+        env:
+          RUSTFLAGS: ${{ env.ALL_UNSUPPORTED_CFG }}
 
   check-external-types:
     name: Validate external types appearing in public API

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,10 +190,13 @@ jobs:
         run: cargo build --locked --no-default-features --target ${{ env.NO_STD_BUILD_TARGET }}
         working-directory: rustls
 
-      - name: cargo build (debug; no default features; no-std, hashbrown) with no-std target - ${{ env.NO_STD_BUILD_TARGET }}
+      - name: cargo build (debug; no default features; no-std, hashbrown_cfg_not_supported) with no-std target - ${{ env.NO_STD_BUILD_TARGET }}
         # (KEEPING --no-default-features which has no effect on main crate in this fork)
+        # NOTE: KEEPING --features hashbrown TO INSTALL hashbrown from dependencies
         run: cargo build --locked --no-default-features --features hashbrown --target ${{ env.NO_STD_BUILD_TARGET }}
         working-directory: rustls
+        env:
+          RUSTFLAGS: --cfg hashbrown_cfg_not_supported
 
       # NOTE: no features are enabled by default on main crate in this fork
       - name: cargo test (debug; default features)

--- a/.github/workflows/portable-rustls-ci-build.yml
+++ b/.github/workflows/portable-rustls-ci-build.yml
@@ -16,6 +16,7 @@ on:
 
 env:
   MAIN_CRATE: portable-rustls
+  ALL_UNSUPPORTED_CFG: --cfg hashbrown_cfg_not_supported --cfg cfg_aws_lc_rs_not_supported
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -208,4 +209,4 @@ jobs:
           RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
       - run: cross test --all-features --package ${{ env.MAIN_CRATE }} --target ${{ matrix.target }}
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc ${{ env.ALL_UNSUPPORTED_CFG }}

--- a/.github/workflows/portable-rustls-ci-build.yml
+++ b/.github/workflows/portable-rustls-ci-build.yml
@@ -70,10 +70,6 @@ jobs:
         env:
           RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
-      # NOTE: BUILD with hashbrown FAILS with no atomic ptr - MISSING SUPPORT in default hasher
-      # - name: cargo build (debug; no-std; hashbrown) # (with no built-in provider)
-      #   ...
-
   test:
     # GENERAL NOTE: NO CI TESTING for no-std
     # (CI TESTING with no-std & with no atomic ptr FOR FUTURE CONSIDERATION)

--- a/bogo/Cargo.toml
+++ b/bogo/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2021"
 base64 = { workspace = true }
 env_logger = { workspace = true }
 # WITH ADAPTED MAIN PACKAGE NAME for this fork
-rustls = { package = "portable-rustls", path = "../rustls", features = ["aws-lc-rs", "ring", "std", "tls12"] }
+rustls = { package = "portable-rustls", path = "../rustls", features = [
+  "include-extra-cfg-dependencies",
+  "ring",
+  "std",
+  "tls12",
+] }
 rustls-post-quantum = { path = "../rustls-post-quantum", optional = true }
 
 [features]

--- a/ci-bench/Cargo.toml
+++ b/ci-bench/Cargo.toml
@@ -15,7 +15,12 @@ fxhash = { workspace = true }
 itertools = { workspace = true }
 rayon = { workspace = true }
 # WITH ADAPTED MAIN PACKAGE NAME for this fork
-rustls = { package = "portable-rustls", path = "../rustls", features = ["aws-lc-rs", "ring", "std", "tls12"] }
+rustls = { package = "portable-rustls", path = "../rustls", features = [
+  "include-extra-cfg-dependencies",
+  "ring",
+  "std",
+  "tls12",
+] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,7 +15,11 @@ log = { workspace = true }
 mio = { workspace = true }
 rcgen = { workspace = true }
 # WITH ADAPTED MAIN PACKAGE NAME for this fork
-rustls = { package = "portable-rustls", path = "../rustls", features = ["aws-lc-rs", "std", "tls12"] }
+rustls = { package = "portable-rustls", path = "../rustls", features = [
+  "include-extra-cfg-dependencies",
+  "std",
+  "tls12",
+] }
 serde = { workspace = true }
 tokio = { workspace = true }
 webpki-roots = { workspace = true }

--- a/openssl-tests/Cargo.toml
+++ b/openssl-tests/Cargo.toml
@@ -12,5 +12,9 @@ base64 = { workspace = true }
 num-bigint = { workspace = true }
 once_cell = { workspace = true }
 # WITH ADAPTED MAIN PACKAGE NAME for this fork
-rustls = { package = "portable-rustls", path = "../rustls", features = ["aws-lc-rs", "std", "tls12"] }
+rustls = { package = "portable-rustls", path = "../rustls", features = [
+  "include-extra-cfg-dependencies",
+  "std",
+  "tls12",
+] }
 openssl = { workspace = true }

--- a/rustls-bench/Cargo.toml
+++ b/rustls-bench/Cargo.toml
@@ -10,7 +10,7 @@ rustls-post-quantum = { path = "../rustls-post-quantum", optional = true }
 
 [features]
 default = []
-aws-lc-rs = ["rustls/aws-lc-rs"]
+include-extra-cfg-dependencies = ["rustls/include-extra-cfg-dependencies"]
 # [FIPS REMOVED FROM THIS FORK] fips = ...
 post-quantum = ["dep:rustls-post-quantum"]
 ring = ["rustls/ring"]

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -926,7 +926,7 @@ impl ResumptionParam {
 
 #[derive(Copy, Clone, Debug, PartialEq, ValueEnum)]
 enum Provider {
-    #[cfg(feature = "aws-lc-rs")]
+    #[cfg(cfg_aws_lc_rs_not_supported)]
     AwsLcRs,
     // [FIPS REMOVED FROM THIS FORK]
     // #[cfg(all(..., ... "fips"))]
@@ -942,7 +942,7 @@ enum Provider {
 impl Provider {
     fn build(self) -> CryptoProvider {
         match self {
-            #[cfg(feature = "aws-lc-rs")]
+            #[cfg(cfg_aws_lc_rs_not_supported)]
             Self::AwsLcRs => rustls::crypto::aws_lc_rs::default_provider(),
             // [FIPS REMOVED FROM THIS FORK]
             // #[cfg(all(..., ... "fips"))]
@@ -957,7 +957,7 @@ impl Provider {
 
     fn ticketer(self) -> Result<Arc<dyn ProducesTickets>, Error> {
         match self {
-            #[cfg(feature = "aws-lc-rs")]
+            #[cfg(cfg_aws_lc_rs_not_supported)]
             Self::AwsLcRs => rustls::crypto::aws_lc_rs::Ticketer::new(),
             // [FIPS REMOVED FROM THIS FORK]
             // #[cfg(all(..., ... "fips"))]
@@ -994,7 +994,7 @@ impl Provider {
         #[allow(unused_mut)]
         let mut available = vec![];
 
-        #[cfg(feature = "aws-lc-rs")]
+        #[cfg(cfg_aws_lc_rs_not_supported)]
         available.push(Self::AwsLcRs);
 
         // [FIPS REMOVED FROM THIS FORK]

--- a/rustls-post-quantum/Cargo.toml
+++ b/rustls-post-quantum/Cargo.toml
@@ -15,7 +15,7 @@ autobenches = false
 [dependencies]
 # WITH ADAPTED MAIN PACKAGE NAME for this fork (MISSING version - should be OK in this fork)
 rustls = { package = "portable-rustls", path = "../rustls", features = [
-  "aws-lc-rs",
+  "include-extra-cfg-dependencies",
   "prefer-post-quantum",
   "std",
 ] }

--- a/rustls-provider-test/Cargo.toml
+++ b/rustls-provider-test/Cargo.toml
@@ -10,6 +10,9 @@ publish = false
 hex = "0.4"
 provider-example = { package = "rustls-provider-example", version = "0.0.1", path = "../provider-example" }
 # WITH ADAPTED MAIN PACKAGE NAME for this fork (MISSING version - should be OK in this fork)
-rustls = { features = ["aws_lc_rs", "logging"], package = "portable-rustls", path = "../rustls" }
+rustls = { features = [
+  "include-extra-cfg-dependencies",
+  "logging",
+], package = "portable-rustls", path = "../rustls" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -17,13 +17,25 @@ build = "build.rs"
 [features]
 default = []
 
-aws-lc-rs = ["aws_lc_rs"] # ALIAS - FAVORED OVER `aws_lc_rs` FEATURE NAME IN THIS FORK
-aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
+# XXX TBD XXX XXX
+include-extra-cfg-dependencies = [
+  # XXX aws-lc-rs
+  "dep:aws-lc-rs",
+  "webpki/aws_lc_rs",
+  # XXX hashbrown
+  "hashbrown",
+]
+
+# XXX TODO REMOVE aws-lc-rs:
+# aws-lc-rs = ["aws_lc_rs"] # ALIAS - FAVORED OVER `aws_lc_rs` FEATURE NAME IN THIS FORK
+# aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]
 brotli = ["dep:brotli", "dep:brotli-decompressor", "std"]
 custom-provider = []
 # [FIPS REMOVED FROM THIS FORK] fips = ...
 logging = ["log"]
-prefer-post-quantum = ["aws-lc-rs"]
+# XXX TBD XXX XXX
+# prefer-post-quantum = ["aws-lc-rs"]
+prefer-post-quantum = ["include-extra-cfg-dependencies"]
 read_buf = ["rustversion", "std"]
 ring = ["dep:ring", "webpki/ring"]
 std = ["webpki/std", "pki-types/std", "once_cell/std"]

--- a/rustls/src/builder.rs
+++ b/rustls/src/builder.rs
@@ -30,7 +30,7 @@ use crate::{ClientConfig, ServerConfig};
 /// supported protocol versions.
 ///
 /// ```
-/// # #[cfg(feature = "aws_lc_rs")] {
+/// # #[cfg(cfg_aws_lc_rs_not_supported)] {
 /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 /// # rustls::crypto::aws_lc_rs::default_provider().install_default();
 /// use rustls::{ClientConfig, ServerConfig};
@@ -47,7 +47,7 @@ use crate::{ClientConfig, ServerConfig};
 /// You may also override the choice of protocol versions:
 ///
 /// ```no_run
-/// # #[cfg(feature = "aws_lc_rs")] {
+/// # #[cfg(cfg_aws_lc_rs_not_supported)] {
 /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 /// # rustls::crypto::aws_lc_rs::default_provider().install_default();
 /// # use rustls::ServerConfig;
@@ -84,7 +84,7 @@ use crate::{ClientConfig, ServerConfig};
 /// For example:
 ///
 /// ```
-/// # #[cfg(feature = "aws_lc_rs")] {
+/// # #[cfg(cfg_aws_lc_rs_not_supported)] {
 /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 /// # rustls::crypto::aws_lc_rs::default_provider().install_default();
 /// # use rustls::ClientConfig;
@@ -109,7 +109,7 @@ use crate::{ClientConfig, ServerConfig};
 /// For example:
 ///
 /// ```no_run
-/// # #[cfg(feature = "aws_lc_rs")] {
+/// # #[cfg(cfg_aws_lc_rs_not_supported)] {
 /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 /// # rustls::crypto::aws_lc_rs::default_provider().install_default();
 /// # use rustls::ServerConfig;

--- a/rustls/src/client/handy.rs
+++ b/rustls/src/client/handy.rs
@@ -31,7 +31,7 @@ impl client::ClientSessionStore for NoClientSessionStorage {
     }
 }
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 mod cache {
     use alloc::collections::VecDeque;
     use core::fmt;
@@ -189,7 +189,7 @@ mod cache {
     }
 }
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 pub use cache::ClientSessionMemoryCache;
 
 #[derive(Debug)]

--- a/rustls/src/crypto/aws_lc_rs/mod.rs
+++ b/rustls/src/crypto/aws_lc_rs/mod.rs
@@ -32,7 +32,7 @@ pub(crate) mod hmac;
 pub(crate) mod kx;
 #[path = "../ring/quic.rs"]
 pub(crate) mod quic;
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 pub(crate) mod ticketer;
 #[cfg(feature = "tls12")]
 pub(crate) mod tls12;
@@ -257,7 +257,7 @@ pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] = &[
     kx_group::MLKEM768,
 ];
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 pub use ticketer::Ticketer;
 
 /// Compatibility shims between ring 0.16.x and 0.17.x API

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -26,7 +26,7 @@ use crate::{suites, Error, NamedGroup, ProtocolVersion, SupportedProtocolVersion
 pub mod ring;
 
 /// aws-lc-rs-based CryptoProvider.
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(cfg_aws_lc_rs_not_supported)]
 pub mod aws_lc_rs;
 
 /// TLS message encryption/decryption interfaces.
@@ -58,6 +58,7 @@ pub use crate::suites::CipherSuiteCommon;
 
 /// Controls core cryptography used by rustls.
 ///
+/// <!-- XXX TODO XXX
 /// This crate comes with two built-in options, provided as
 /// `CryptoProvider` structures:
 ///
@@ -123,7 +124,7 @@ pub use crate::suites::CipherSuiteCommon;
 /// API ([`ConfigBuilder::with_single_cert`] etc.), it might look like this:
 ///
 /// ```
-/// # #[cfg(feature = "aws_lc_rs")] {
+/// # #[cfg(cfg_aws_lc_rs_not_supported)] {
 /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 /// # use std::sync::Arc;
 /// # mod fictious_hsm_api { pub fn load_private_key(key_der: pki_types::PrivateKeyDer<'static>) -> ! { unreachable!(); } }
@@ -181,6 +182,7 @@ pub use crate::suites::CipherSuiteCommon;
 ///
 /// You can verify the configuration at runtime by checking
 /// [`ServerConfig::fips()`]/[`ClientConfig::fips()`] return `true`.
+/// -- XXX -->
 #[derive(Debug, Clone)]
 pub struct CryptoProvider {
     /// List of supported ciphersuites, in preference order -- the first element
@@ -262,7 +264,7 @@ impl CryptoProvider {
     fn from_crate_features() -> Option<Self> {
         #[cfg(all(
             feature = "ring",
-            not(feature = "aws_lc_rs"),
+            not(cfg_aws_lc_rs_not_supported),
             not(feature = "custom-provider")
         ))]
         {
@@ -270,7 +272,7 @@ impl CryptoProvider {
         }
 
         #[cfg(all(
-            feature = "aws_lc_rs",
+            cfg_aws_lc_rs_not_supported,
             not(feature = "ring"),
             not(feature = "custom-provider")
         ))]

--- a/rustls/src/crypto/ring/mod.rs
+++ b/rustls/src/crypto/ring/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod hash;
 pub(crate) mod hmac;
 pub(crate) mod kx;
 pub(crate) mod quic;
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 pub(crate) mod ticketer;
 #[cfg(feature = "tls12")]
 pub(crate) mod tls12;
@@ -177,7 +177,7 @@ pub static DEFAULT_KX_GROUPS: &[&dyn SupportedKxGroup] = ALL_KX_GROUPS;
 pub static ALL_KX_GROUPS: &[&dyn SupportedKxGroup] =
     &[kx_group::X25519, kx_group::SECP256R1, kx_group::SECP384R1];
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 pub use ticketer::Ticketer;
 
 /// Compatibility shims between ring 0.16.x and 0.17.x API

--- a/rustls/src/crypto/signer.rs
+++ b/rustls/src/crypto/signer.rs
@@ -22,6 +22,7 @@ use super::CryptoProvider;
 /// `Arc<dyn SigningKey>`. There are no concrete public structs in Rustls
 /// that implement this trait.
 ///
+/// <!-- XXX TODO XXX
 /// There are two main ways to get a signing key:
 ///
 ///  - [`KeyProvider::load_private_key()`], or
@@ -57,6 +58,7 @@ use super::CryptoProvider;
 /// [`ResolvesServerCertUsingSni`]: crate::server::ResolvesServerCertUsingSni
 /// [`ResolvesServerCert`]: crate::server::ResolvesServerCert
 /// [`ResolvesClientCert`]: crate::client::ResolvesClientCert
+/// -- XXX -->
 pub trait SigningKey: Debug + Send + Sync {
     /// Choose a `SignatureScheme` from those offered.
     ///
@@ -202,7 +204,7 @@ impl CertifiedKey {
     }
 }
 
-#[cfg_attr(not(any(feature = "aws_lc_rs", feature = "ring")), allow(dead_code))]
+#[cfg_attr(not(any(cfg_aws_lc_rs_not_supported, feature = "ring")), allow(dead_code))]
 pub(crate) fn public_key_to_spki(
     alg_id: &AlgorithmIdentifier,
     public_key: impl AsRef<[u8]>,

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -183,7 +183,7 @@
 //! the Mozilla set of root certificates.
 //!
 //! ```rust,no_run
-//! # #[cfg(feature = "aws-lc-rs")] {
+//! # #[cfg(cfg_aws_lc_rs_not_supported)] {
 //! # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 //! let root_store = rustls::RootCertStore::from_iter(
 //!     webpki_roots::TLS_SERVER_ROOTS
@@ -199,7 +199,7 @@
 //! and use it for all connections made by that process.
 //!
 //! ```rust,no_run
-//! # #[cfg(feature = "aws_lc_rs")] {
+//! # #[cfg(cfg_aws_lc_rs_not_supported)] {
 //! # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 //! # let root_store: rustls::RootCertStore = panic!();
 //! let config = rustls::ClientConfig::builder()
@@ -212,7 +212,7 @@
 //! know what to expect to find in the server's certificate.
 //!
 //! ```rust
-//! # #[cfg(feature = "aws_lc_rs")] {
+//! # #[cfg(cfg_aws_lc_rs_not_supported)] {
 //! # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 //! # use webpki;
 //! # use std::sync::Arc;
@@ -255,7 +255,7 @@
 //! errors.
 //!
 //! ```rust,no_run
-//! # #[cfg(feature = "aws_lc_rs")] {
+//! # #[cfg(cfg_aws_lc_rs_not_supported)] {
 //! # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 //! # let mut client = rustls::ClientConnection::new(panic!(), panic!()).unwrap();
 //! # struct Socket { }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -479,7 +479,7 @@ mod conn;
 pub mod crypto;
 mod error;
 mod hash_hs;
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 mod limited_cache;
 mod rand;
 mod record_layer;
@@ -615,7 +615,7 @@ pub use crate::suites::{
 };
 #[cfg(feature = "std")]
 pub use crate::ticketer::TicketRotator;
-#[cfg(any(feature = "std", feature = "hashbrown"))] // < XXX: incorrect feature gate
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))] // < XXX: incorrect feature gate
 pub use crate::ticketer::TicketSwitcher;
 #[cfg(feature = "tls12")]
 pub use crate::tls12::Tls12CipherSuite;
@@ -645,7 +645,7 @@ pub mod client {
     pub use client_conn::{ClientConnection, WriteEarlyData};
     pub use ech::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
     pub use handy::AlwaysResolvesClientRawPublicKeys;
-    #[cfg(any(feature = "std", feature = "hashbrown"))]
+    #[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
     pub use handy::ClientSessionMemoryCache;
 
     /// Dangerous configuration that should be audited and used with extreme care.
@@ -678,9 +678,9 @@ pub mod server {
     mod tls13;
 
     pub use builder::WantsServerCert;
-    #[cfg(any(feature = "std", feature = "hashbrown"))]
+    #[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
     pub use handy::ResolvesServerCertUsingSni;
-    #[cfg(any(feature = "std", feature = "hashbrown"))]
+    #[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
     pub use handy::ServerSessionMemoryCache;
     pub use handy::{AlwaysResolvesServerRawPublicKeys, NoServerSessionStorage};
     pub use server_conn::{
@@ -728,7 +728,7 @@ pub mod sign {
 /// APIs for implementing QUIC TLS
 pub mod quic;
 
-#[cfg(any(feature = "std", feature = "hashbrown"))] // < XXX: incorrect feature gate
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))] // < XXX: incorrect feature gate
 /// APIs for implementing TLS tickets
 pub mod ticketer;
 
@@ -743,15 +743,15 @@ pub mod lock;
 /// Polyfills for features that are not yet stabilized or available with current MSRV.
 pub(crate) mod polyfill;
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 mod hash_map {
     #[cfg(feature = "std")]
     pub(crate) use std::collections::hash_map::Entry;
     #[cfg(feature = "std")]
     pub(crate) use std::collections::HashMap;
 
-    #[cfg(all(not(feature = "std"), feature = "hashbrown"))]
+    #[cfg(all(not(feature = "std"), hashbrown_cfg_not_supported))]
     pub(crate) use hashbrown::hash_map::Entry;
-    #[cfg(all(not(feature = "std"), feature = "hashbrown"))]
+    #[cfg(all(not(feature = "std"), hashbrown_cfg_not_supported))]
     pub(crate) use hashbrown::HashMap;
 }

--- a/rustls/src/manual/defaults.rs
+++ b/rustls/src/manual/defaults.rs
@@ -26,6 +26,7 @@ the implementation security will be improved.  We think this is an uncommon case
 Both provide roughly the same classical security level, but x25519 has better performance and
 it's _much_ more likely that both peers will have good quality implementations.
 
+<!-- XXX TODO XXX
 ### About the post-quantum-secure key exchange `X25519MLKEM768`
 
 [`X25519MLKEM768`] -- a hybrid[^1], post-quantum-secure[^2] key exchange
@@ -67,5 +68,6 @@ by default out of conservatism.
 [Cloudflare]: <https://blog.cloudflare.com/pq-2024/#ml-kem-768-and-x25519>
 [interop-bug]: <https://github.com/rustls/rustls/issues/new?assignees=&labels=&projects=&template=bug_report.md&title=>
 [tldr.fail]: <https://tldr.fail/>
+-- XXX -->
 
 */

--- a/rustls/src/server/handy.rs
+++ b/rustls/src/server/handy.rs
@@ -24,7 +24,7 @@ impl server::StoresServerSessions for NoServerSessionStorage {
     }
 }
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 mod cache {
     use alloc::vec::Vec;
     use core::fmt::{Debug, Formatter};
@@ -144,7 +144,7 @@ mod cache {
     }
 }
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 pub use cache::ServerSessionMemoryCache;
 
 /// Something which never produces tickets.
@@ -190,7 +190,7 @@ impl server::ResolvesServerCert for AlwaysResolvesServerRawPublicKeys {
     }
 }
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 mod sni_resolver {
     use alloc::string::{String, ToString};
     use core::fmt::Debug;
@@ -306,7 +306,7 @@ mod sni_resolver {
     }
 }
 
-#[cfg(any(feature = "std", feature = "hashbrown"))]
+#[cfg(any(feature = "std", hashbrown_cfg_not_supported))]
 pub use sni_resolver::ResolvesServerCertUsingSni;
 
 #[cfg(test)]

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -728,7 +728,7 @@ mod connection {
     /// # Example
     ///
     /// ```no_run
-    /// # #[cfg(feature = "aws_lc_rs")] {
+    /// # #[cfg(cfg_aws_lc_rs_not_supported)] {
     /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
     /// # fn choose_server_config(
     /// #     _: rustls::server::ClientHello,

--- a/rustls/src/test_macros.rs
+++ b/rustls/src/test_macros.rs
@@ -16,7 +16,7 @@ macro_rules! test_for_each_provider {
             $($tt)+
         }
 
-        #[cfg(feature = "aws_lc_rs")]
+        #[cfg(cfg_aws_lc_rs_not_supported)]
         mod test_with_aws_lc_rs {
             use crate::crypto::aws_lc_rs as provider;
             #[allow(unused_imports)]
@@ -42,7 +42,7 @@ macro_rules! bench_for_each_provider {
             $($tt)+
         }
 
-        #[cfg(feature = "aws_lc_rs")]
+        #[cfg(cfg_aws_lc_rs_not_supported)]
         mod bench_with_aws_lc_rs {
             use crate::crypto::aws_lc_rs as provider;
             #[allow(unused_imports)]

--- a/rustls/src/webpki/client_verifier.rs
+++ b/rustls/src/webpki/client_verifier.rs
@@ -200,7 +200,7 @@ impl ClientCertVerifierBuilder {
 ///
 /// To require all clients present a client certificate issued by a trusted CA:
 /// ```no_run
-/// # #[cfg(any(feature = "ring", feature = "aws_lc_rs"))] {
+/// # #[cfg(any(feature = "ring", cfg_aws_lc_rs_not_supported))] {
 /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 /// # use rustls::RootCertStore;
 /// # use rustls::server::WebPkiClientVerifier;
@@ -214,7 +214,7 @@ impl ClientCertVerifierBuilder {
 /// Or, to allow clients presenting a client certificate authenticated by a trusted CA, or
 /// anonymous clients that present no client certificate:
 /// ```no_run
-/// # #[cfg(any(feature = "ring", feature = "aws_lc_rs"))] {
+/// # #[cfg(any(feature = "ring", cfg_aws_lc_rs_not_supported))] {
 /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 /// # use rustls::RootCertStore;
 /// # use rustls::server::WebPkiClientVerifier;
@@ -238,7 +238,7 @@ impl ClientCertVerifierBuilder {
 /// You can also configure the client verifier to check for certificate revocation with
 /// client certificate revocation lists (CRLs):
 /// ```no_run
-/// # #[cfg(any(feature = "ring", feature = "aws_lc_rs"))] {
+/// # #[cfg(any(feature = "ring", cfg_aws_lc_rs_not_supported))] {
 /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
 /// # use rustls::RootCertStore;
 /// # use rustls::server::{WebPkiClientVerifier};

--- a/rustls/tests/api.rs
+++ b/rustls/tests/api.rs
@@ -23,7 +23,7 @@ use rustls::internal::msgs::handshake::{
 };
 use rustls::internal::msgs::message::{Message, MessagePayload, PlainMessage};
 use rustls::server::{ClientHello, ParsedCertificate, ResolvesServerCert};
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(cfg_aws_lc_rs_not_supported)]
 use rustls::{
     client::{EchConfig, EchGreaseConfig, EchMode},
     crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES,
@@ -7011,7 +7011,7 @@ fn test_debug_server_name_from_string() {
     )
 }
 
-#[cfg(all(feature = "ring", feature = "aws_lc_rs"))]
+#[cfg(all(feature = "ring", cfg_aws_lc_rs_not_supported))]
 #[test]
 fn test_explicit_provider_selection() {
     let client_config = finish_client_config(
@@ -7247,7 +7247,7 @@ fn test_server_fips_service_indicator_includes_require_ems() {
     assert!(!server_config.fips());
 }
 
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(cfg_aws_lc_rs_not_supported)]
 #[test]
 fn test_client_fips_service_indicator_includes_ech_hpke_suite() {
     if !provider_is_fips() {

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -316,7 +316,7 @@ pub static ALL_KEY_TYPES: &[KeyType] = &[
     KeyType::Rsa4096,
     KeyType::EcdsaP256,
     KeyType::EcdsaP384,
-    #[cfg(all(not(feature = "ring"), feature = "aws_lc_rs"))]
+    #[cfg(all(not(feature = "ring"), cfg_aws_lc_rs_not_supported))]
     KeyType::EcdsaP521,
     KeyType::Ed25519,
 ];
@@ -967,8 +967,8 @@ pub fn do_suite_and_kx_test(
 
 fn exactly_one_provider() -> bool {
     cfg!(any(
-        all(feature = "ring", not(feature = "aws_lc_rs")),
-        all(feature = "aws_lc_rs", not(feature = "ring"))
+        all(feature = "ring", not(cfg_aws_lc_rs_not_supported)),
+        all(cfg_aws_lc_rs_not_supported, not(feature = "ring"))
     ))
 }
 

--- a/rustls/tests/process_provider.rs
+++ b/rustls/tests/process_provider.rs
@@ -1,15 +1,15 @@
-#![cfg(any(feature = "ring", feature = "aws_lc_rs"))]
+#![cfg(any(feature = "ring", cfg_aws_lc_rs_not_supported))]
 
 //! Note that the default test runner builds each test file into a separate
 //! executable, and runs tests in an indeterminate order.  That restricts us
 //! to doing all the desired tests, in series, in one function.
 
 use portable_rustls as rustls; // TEST IMPORT WORKAROUND for this fork
-#[cfg(all(feature = "aws_lc_rs", not(feature = "ring")))]
+#[cfg(all(cfg_aws_lc_rs_not_supported, not(feature = "ring")))]
 use rustls::crypto::aws_lc_rs as provider;
-#[cfg(all(feature = "ring", not(feature = "aws_lc_rs")))]
+#[cfg(all(feature = "ring", not(cfg_aws_lc_rs_not_supported)))]
 use rustls::crypto::ring as provider;
-#[cfg(all(feature = "ring", feature = "aws_lc_rs"))]
+#[cfg(all(feature = "ring", cfg_aws_lc_rs_not_supported))]
 use rustls::crypto::ring as provider;
 use rustls::crypto::CryptoProvider;
 use rustls::ClientConfig;
@@ -19,11 +19,11 @@ use crate::common::*;
 
 #[test]
 fn test_process_provider() {
-    if dbg!(cfg!(all(feature = "ring", feature = "aws_lc_rs"))) {
+    if dbg!(cfg!(all(feature = "ring", cfg_aws_lc_rs_not_supported))) {
         test_explicit_choice_required();
-    } else if dbg!(cfg!(all(feature = "ring", not(feature = "aws_lc_rs")))) {
+    } else if dbg!(cfg!(all(feature = "ring", not(cfg_aws_lc_rs_not_supported)))) {
         test_ring_used_as_implicit_provider();
-    } else if dbg!(cfg!(all(feature = "aws_lc_rs", not(feature = "ring")))) {
+    } else if dbg!(cfg!(all(cfg_aws_lc_rs_not_supported, not(feature = "ring")))) {
         test_aws_lc_rs_used_as_implicit_provider();
     } else {
         panic!("fix feature combinations");

--- a/rustls/tests/runners/api.rs
+++ b/rustls/tests/runners/api.rs
@@ -17,7 +17,7 @@ mod tests_with_ring {
     mod tests;
 }
 
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(cfg_aws_lc_rs_not_supported)]
 #[path = "."]
 mod tests_with_aws_lc_rs {
     use super::*;

--- a/rustls/tests/runners/api_ffdhe.rs
+++ b/rustls/tests/runners/api_ffdhe.rs
@@ -10,7 +10,7 @@ mod tests_with_ring {
     mod tests;
 }
 
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(cfg_aws_lc_rs_not_supported)]
 #[path = "."]
 mod tests_with_aws_lc_rs {
     provider_aws_lc_rs!();

--- a/rustls/tests/runners/client_cert_verifier.rs
+++ b/rustls/tests/runners/client_cert_verifier.rs
@@ -10,7 +10,7 @@ mod tests_with_ring {
     mod tests;
 }
 
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(cfg_aws_lc_rs_not_supported)]
 #[path = "."]
 mod tests_with_aws_lc_rs {
     provider_aws_lc_rs!();

--- a/rustls/tests/runners/key_log_file_env.rs
+++ b/rustls/tests/runners/key_log_file_env.rs
@@ -15,7 +15,7 @@ mod tests_with_ring {
     mod tests;
 }
 
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(cfg_aws_lc_rs_not_supported)]
 #[path = "."]
 mod tests_with_aws_lc_rs {
     use super::serialized;

--- a/rustls/tests/runners/server_cert_verifier.rs
+++ b/rustls/tests/runners/server_cert_verifier.rs
@@ -10,7 +10,7 @@ mod tests_with_ring {
     mod tests;
 }
 
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(cfg_aws_lc_rs_not_supported)]
 #[path = "."]
 mod tests_with_aws_lc_rs {
     provider_aws_lc_rs!();

--- a/rustls/tests/runners/unbuffered.rs
+++ b/rustls/tests/runners/unbuffered.rs
@@ -10,7 +10,7 @@ mod tests_with_ring {
     mod tests;
 }
 
-#[cfg(feature = "aws_lc_rs")]
+#[cfg(cfg_aws_lc_rs_not_supported)]
 #[path = "."]
 mod tests_with_aws_lc_rs {
     provider_aws_lc_rs!();


### PR DESCRIPTION
__STATUS - GENERAL__

This proposal is intended to target new embedded-rustls fork, as discussed in: issue #29

Starting off with dropping hashbrown, which is an implicit feature (only shows up in dependencies, not in features in Config.toml).

The good news is that there do not seem to be any issues with the CI testing.

---

__OUTDATED STATUS - MOVING FORWARD__

~~At this point I am pretty reluctant to continue further with these updates. Running `cargo doc` with these updates shows the following text in the documentation for the `ticketer` module:~~

__UPDATE:__ This extra cfg info *only* seem to appear when using a pattern like this: `#[cfg(any(feature = "std", hashbrown_cfg_not_supported))] // < XXX: incorrect feature gate`

<blockquote>
<div class="stab portability">Available on <strong>crate feature <code>std</code> or <code>hashbrown_cfg_not_supported</code></strong> only.</div>
</blockquote>

Unfortuntately this info DOES appear on in index.html, I hope to find a way to get rid of this in index.html.