### PR TITLE
[portable-rustls] export Arc type alias from this crate

### DIFF
--- a/.github/workflows/portable-rustls-ci-build.yml
+++ b/.github/workflows/portable-rustls-ci-build.yml
@@ -220,3 +220,99 @@ jobs:
       - run: cross test --all-features --package ${{ env.MAIN_CRATE }} --target ${{ matrix.target }}
         env:
           RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+
+  full-build:
+    # ensure everything builds together with this build cfg option enabled
+    # (with help from exported `Arc` alias)
+    name: full build with unstable_portable_atomic_arc cfg
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        rust:
+          - nightly
+          # try a few Rust nightly versions
+          - nightly-2024-07-01
+          - nightly-2024-01-01
+          - nightly-2023-12-01
+          # SEEMS TO PANIC
+          # - nightly-2023-11-01
+          # OK WITH NO FEATURES ENABLED (issue with --all-features due to `zlib`)
+          - nightly-2023-10-01
+          # KNOWN BUILD FAILURE
+          # - nightly-2023-09-01
+        os:
+          - ubuntu-latest
+          # FOR FUTURE CONSIDERATION:
+          # - macos-latest
+          # - windows-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install ${{ matrix.rust }} toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: cargo build (debug; no-std) # (with no built-in provider)
+        run: cargo build
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+
+      - name: cargo build (debug; std; all features)
+        # QUICK WORKAROUND TO AVOID BUILD ISSUE WITH RUST NIGHTLY FROM OCTOBER 2023
+        if: ${{ !startsWith(matrix.rust, 'nightly-2023-10') }}
+        run: cargo build --all-features
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+
+  full-test:
+    # test everything builds together with this build cfg option enabled
+    # (with help from exported `Arc` alias)
+    name: full test with unstable_portable_atomic_arc cfg
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        rust:
+          - nightly
+          - nightly-2024-07-01
+          # TEST BUILD FAILURE WITH OLDER RUST NIGHTLY VERSIONS
+          # - nightly-2024-06-01
+          # ...
+        os:
+          - ubuntu-latest
+          # FOR FUTURE CONSIDERATION:
+          # - macos-latest
+          # - windows-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install ${{ matrix.rust }} toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: cargo test (debug; no-std) # (with no built-in provider)
+        run: cargo test
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+
+      - name: cargo test (debug; std; all features)
+        run: cargo test --all-features
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+
+      - name: cargo test (debug; rustls-provider-example; all features)
+        run: cargo test --all-features -p rustls-provider-example
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+
+      - name: cargo test (debug; rustls-provider-test; all features)
+        run: cargo test --all-features -p rustls-provider-test
+        env:
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc

--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ Then import and use __`rustls`__ in the code as usual.
 
 (Unlike the original __`rustls`__, no features are enabled by default in this fork.)
 
+<!-- TODO: [...][crate::Arc] pattern is replaced by `admin/pull-readme` - TODO REFERENCE docs.rs when possible -->
+Note that this fork provides a crate-level `Arc` type alias to help use the correct `Arc` type according to the build configuration:
+
+- alias to [`portable_atomic_util::Arc`](https://docs.rs/portable-atomic-util/latest/portable_atomic_util/struct.Arc.html),
+if `RUSTFLAGS` is set with `--cfg unstable_portable_atomic_arc` during Cargo build
+- otherwise alias to [`alloc::sync::Arc`](https://doc.rust-lang.org/nightly/alloc/sync/struct.Arc.html) / [`std::sync::Arc`](https://doc.rust-lang.org/nightly/std/sync/struct.Arc.html)
+
+It is recommended to simply import the crate-level `Arc` type alias from this crate:
+
+```rust,ignore
+use rustls::Arc;
+```
+
 ### targets with no atomic ptr
 
 This fork supports using `Arc` from `portable-atomic-util` to support targets with no atomic ptr, with the following requirements:

--- a/admin/pull-readme
+++ b/admin/pull-readme
@@ -8,6 +8,7 @@ grep '^//!' rustls/src/lib.rs | \
        sed -e 's@^\/\/\! *@@g' | \
        sed -e 's@](manual::_04_features)@](https://docs.rs/portable-rustls/latest/portable_rustls/manual/_04_features/index.html)@' | \
        sed -e 's@\[`crypto::CryptoProvider`\]: crate::crypto::CryptoProvider@[`crypto::CryptoProvider`]: https://docs.rs/portable-rustls/latest/portable_rustls/crypto/struct.CryptoProvider.html@' | \
+       sed -e 's@\[`Arc` type alias\]\[crate::Arc\]@`Arc` type alias@' | \
        awk '/# Rustls - a modern TLS library/{take=1;next}/## Design overview/{take=0}take' >> README.md.new
 awk '/# Example code/{take=1}take' < README.md >> README.md.new
 mv README.md.new README.md

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -6,10 +6,12 @@
 
 use std::fmt::{Debug, Formatter};
 use std::io::{self, Read, Write};
-use std::sync::Arc;
 use std::{env, net, process, thread, time};
 
 use base64::prelude::{Engine, BASE64_STANDARD};
+
+use rustls::Arc;
+
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::client::{
     ClientConfig, ClientConnection, EchConfig, EchGreaseConfig, EchMode, EchStatus, Resumption,

--- a/ci-bench/src/benchmark.rs
+++ b/ci-bench/src/benchmark.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
-
 use fxhash::FxHashMap;
 use itertools::Itertools;
+
+use rustls::Arc;
 
 use crate::callgrind::InstructionCounts;
 use crate::util::KeyType;

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -5,7 +5,6 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::mem;
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Context;
@@ -15,6 +14,9 @@ use fxhash::FxHashMap;
 use itertools::Itertools;
 use rayon::iter::Either;
 use rayon::prelude::*;
+
+use rustls::Arc;
+
 use rustls::client::Resumption;
 use rustls::crypto::{aws_lc_rs, ring, CryptoProvider, GetRandomFailed, SecureRandom};
 use rustls::pki_types::pem::PemObject;

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -32,7 +32,6 @@ use std::error::Error;
 use std::fs;
 use std::io::{stdout, BufReader, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::sync::Arc;
 
 use clap::Parser;
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
@@ -40,6 +39,9 @@ use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
 use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::{ResolveError, Resolver, TokioResolver};
 use log::trace;
+
+use rustls::Arc;
+
 use rustls::client::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -4,7 +4,8 @@
 
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 

--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -8,12 +8,14 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::ops::Add;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
 use std::{fs, thread};
 
 use clap::Parser;
 use rcgen::KeyPair;
+
+use rustls::Arc;
+
 use rustls::pki_types::{CertificateRevocationListDer, PrivatePkcs8KeyDer};
 use rustls::server::{Acceptor, ClientHello, ServerConfig, WebPkiClientVerifier};
 use rustls::RootCertStore;

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -17,7 +17,8 @@ use std::env;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::str::FromStr;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, ServerName};

--- a/examples/src/bin/simple_0rtt_server.rs
+++ b/examples/src/bin/simple_0rtt_server.rs
@@ -15,8 +15,9 @@
 use std::error::Error as StdError;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::Arc;
 use std::{env, io};
+
+use rustls::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -10,7 +10,8 @@
 
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::RootCertStore;
 

--- a/examples/src/bin/simpleserver.rs
+++ b/examples/src/bin/simpleserver.rs
@@ -11,7 +11,8 @@ use std::env;
 use std::error::Error as StdError;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -21,11 +21,13 @@
 
 use std::io::{self, Read, Write};
 use std::net::ToSocketAddrs;
-use std::sync::Arc;
 use std::{process, str};
 
 use clap::Parser;
 use mio::net::TcpStream;
+
+use rustls::Arc;
+
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -22,12 +22,14 @@
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::{fs, net};
 
 use clap::{Parser, Subcommand};
 use log::{debug, error};
 use mio::net::{TcpListener, TcpStream};
+
+use rustls::Arc;
+
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};

--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -3,12 +3,14 @@
 //! using asynchronous I/O using either async-std or tokio.
 
 use std::error::Error;
-use std::sync::Arc;
 
 #[cfg(feature = "async-std")]
 use async_std::io::{ReadExt, WriteExt};
 #[cfg(feature = "async-std")]
 use async_std::net::TcpStream;
+
+use rustls::Arc;
+
 use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
 use rustls::unbuffered::{
     AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -4,7 +4,8 @@
 use std::error::Error;
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::client::{ClientConnectionData, EarlyDataError, UnbufferedClientConnection};
 use rustls::unbuffered::{

--- a/examples/src/bin/unbuffered-server.rs
+++ b/examples/src/bin/unbuffered-server.rs
@@ -6,7 +6,8 @@ use std::error::Error;
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -4,7 +4,8 @@ extern crate libfuzzer_sys;
 extern crate rustls;
 
 use std::io;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::{ClientConfig, ClientConnection};
 

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -4,7 +4,8 @@ extern crate libfuzzer_sys;
 extern crate rustls;
 
 use std::io;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::server::{Accepted, Acceptor};
 use rustls::{ServerConfig, ServerConnection};

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -1,9 +1,11 @@
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::sync::Arc;
 use std::{fs, str, thread};
 
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
+
+use rustls::Arc;
+
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -7,7 +7,8 @@
 mod client {
     use std::io::{self, Read, Write};
     use std::net::TcpStream;
-    use std::sync::Arc;
+
+    use rustls::Arc;
 
     use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
     use rustls::client::AlwaysResolvesClientRawPublicKeys;
@@ -158,7 +159,8 @@ mod client {
 mod server {
     use std::io::{self, ErrorKind, Read, Write};
     use std::net::TcpListener;
-    use std::sync::Arc;
+
+    use rustls::Arc;
 
     use rustls::client::danger::HandshakeSignatureValid;
     use rustls::crypto::{

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -1,6 +1,7 @@
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 fn main() {
     env_logger::init();

--- a/provider-example/examples/server.rs
+++ b/provider-example/examples/server.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::Acceptor;

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -5,6 +5,10 @@ use core::fmt::Debug;
 use hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
 use hpke_rs_crypto::HpkeCrypto;
 use hpke_rs_rust_crypto::HpkeRustCrypto;
+
+#[cfg(feature = "std")]
+use rustls::Arc;
+
 use rustls::crypto::hpke::{
     EncapsulatedSecret, Hpke, HpkeOpener, HpkePrivateKey, HpkePublicKey, HpkeSealer, HpkeSuite,
 };
@@ -213,7 +217,7 @@ impl HpkeOpener for HpkeRsReceiver {
 
 #[cfg(feature = "std")]
 fn other_err(err: impl std::error::Error + Send + Sync + 'static) -> Error {
-    Error::Other(OtherError(alloc::sync::Arc::new(err)))
+    Error::Other(OtherError(Arc::new(err)))
 }
 
 #[cfg(not(feature = "std"))]

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-use alloc::sync::Arc;
+use rustls::Arc;
 
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::PrivateKeyDer;

--- a/provider-example/src/sign.rs
+++ b/provider-example/src/sign.rs
@@ -1,8 +1,10 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use pkcs8::DecodePrivateKey;
+
+use rustls::Arc;
+
 use rustls::pki_types::PrivateKeyDer;
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -7,11 +7,13 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{mem, thread};
 
 use clap::{Parser, ValueEnum};
+
+use rustls::Arc;
+
 use rustls::client::{Resumption, UnbufferedClientConnection};
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::pem::PemObject;

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use rustls::Arc;
 
 use rustls::client::danger::ServerCertVerifier;
 use rustls::client::WebPkiServerVerifier;
@@ -21,6 +21,7 @@ use rustls::{
     PeerMisbehaved, ProtocolVersion, RootCertStore, SignatureAlgorithm, SignatureScheme,
     SupportedCipherSuite, Tls12CipherSuite, Tls13CipherSuite,
 };
+
 use webpki::alg_id;
 
 /// This is a `CryptoProvider` that provides NO SECURITY and is for fuzzing only.

--- a/rustls-post-quantum/benches/benchmarks.rs
+++ b/rustls-post-quantum/benches/benchmarks.rs
@@ -1,6 +1,7 @@
-use std::sync::Arc;
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+
+use rustls::Arc;
+
 use rustls::crypto::aws_lc_rs::kx_group::X25519;
 use rustls::crypto::{
     aws_lc_rs, ActiveKeyExchange, CryptoProvider, SharedSecret, SupportedKxGroup,

--- a/rustls-post-quantum/examples/client.rs
+++ b/rustls-post-quantum/examples/client.rs
@@ -9,7 +9,8 @@
 
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 fn main() {
     env_logger::init();

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -6,9 +6,10 @@ use rustls::crypto::ring as provider;
 #[path = "../tests/common/mod.rs"]
 mod test_utils;
 use std::io;
-use std::sync::Arc;
 
 use portable_rustls as rustls; // TEST IMPORT WORKAROUND for this fork
+
+use rustls::Arc;
 
 use rustls::ServerConnection;
 use test_utils::*;

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -125,7 +125,7 @@ pub use crate::suites::CipherSuiteCommon;
 /// ```
 /// # #[cfg(feature = "aws_lc_rs")] {
 /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
-/// # use std::sync::Arc;
+/// # use rustls::Arc; // EXPORTED ALIAS
 /// # mod fictious_hsm_api { pub fn load_private_key(key_der: pki_types::PrivateKeyDer<'static>) -> ! { unreachable!(); } }
 /// use rustls::crypto::aws_lc_rs;
 ///

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -20,6 +20,19 @@
 //!
 //! (Unlike the original __`rustls`__, no features are enabled by default in this fork.)
 //!
+//! <!-- TODO: [...][crate::Arc] pattern is replaced by `admin/pull-readme` - TODO REFERENCE docs.rs when possible -->
+//! Note that this fork provides a crate-level [`Arc` type alias][crate::Arc] to help use the correct `Arc` type according to the build configuration:
+//!
+//! - alias to [`portable_atomic_util::Arc`](https://docs.rs/portable-atomic-util/latest/portable_atomic_util/struct.Arc.html),
+//!   if `RUSTFLAGS` is set with `--cfg unstable_portable_atomic_arc` during Cargo build
+//! - otherwise alias to [`alloc::sync::Arc`](https://doc.rust-lang.org/nightly/alloc/sync/struct.Arc.html) / [`std::sync::Arc`](https://doc.rust-lang.org/nightly/std/sync/struct.Arc.html)
+//!
+//! It is recommended to simply import the crate-level [`Arc` type alias][crate::Arc] from this crate:
+//!
+//! ```rust,ignore
+//! use rustls::Arc;
+//! ```
+//!
 //! ### targets with no atomic ptr
 //!
 //! This fork supports using `Arc` from `portable-atomic-util` to support targets with no atomic ptr, with the following requirements:
@@ -256,8 +269,8 @@
 //! ```rust
 //! # #[cfg(feature = "aws_lc_rs")] {
 //! # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
+//! # use rustls::Arc; // EXPORTED ALIAS
 //! # use webpki;
-//! # use std::sync::Arc;
 //! # rustls::crypto::aws_lc_rs::default_provider().install_default();
 //! # let root_store = rustls::RootCertStore::from_iter(
 //! #  webpki_roots::TLS_SERVER_ROOTS
@@ -508,10 +521,23 @@ mod log {
 #[macro_use]
 mod test_macros;
 
+/// `Arc` type alias for this entire crate - may alias to either of these depending on the cfg used when building:
+/// - [`portable_atomic_util::Arc`](https://docs.rs/portable-atomic-util/latest/portable_atomic_util/struct.Arc.html)
+/// - [`alloc::sync::Arc`] / [`std::sync::Arc`](https://doc.rust-lang.org/nightly/std/sync/struct.Arc.html)
+#[allow(unused_qualifications)]
+pub type Arc<T> = crate::arc_type_alias::Arc<T>;
+
 /// This internal `sync` module aliases the `Arc` implementation to allow downstream forks
 /// of rustls targetting architectures without atomic pointers to replace the implementation
 /// with another implementation such as `portable_atomic_util::Arc` in one central location.
 mod sync {
+    // Arc type alias as exported by the public API above
+    pub(crate) use crate::Arc;
+}
+
+/// Keeping the extra level of indirection with this separate internal module so that
+/// the generated doc shows use of exported Arc alias from this crate.
+mod arc_type_alias {
     #[cfg(unstable_portable_atomic_arc)]
     #[allow(clippy::disallowed_types)]
     pub(crate) type Arc<T> = portable_atomic_util::Arc<T>;

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -732,9 +732,10 @@ mod connection {
     /// ```no_run
     /// # #[cfg(feature = "aws_lc_rs")] {
     /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
+    /// # use rustls::Arc; // EXPORTED ALIAS
     /// # fn choose_server_config(
     /// #     _: rustls::server::ClientHello,
-    /// # ) -> std::sync::Arc<rustls::ServerConfig> {
+    /// # ) -> Arc<rustls::ServerConfig> {
     /// #     unimplemented!();
     /// # }
     /// # #[allow(unused_variables)]

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -38,10 +38,7 @@ use webpki::anchor_from_trusted_cert;
 use super::provider;
 
 // UPDATED IN THIS FORK (THIS IMPORT ONLY SEEMS TO BE NEEDED FOR `aws_lc_rs` & `ring` features)
-#[cfg(unstable_portable_atomic_arc)]
-pub use portable_atomic_util::Arc;
-#[cfg(not(unstable_portable_atomic_arc))]
-pub use std::sync::Arc;
+pub use rustls::Arc;
 
 macro_rules! embed_files {
     (


### PR DESCRIPTION
__UPDATED STATUS:__

~~I am thinking it may be easiest to do this update as part of other PR #49.~~

I would like to keep this update separate from PR #49, with some other updates:

- update benchmark code, examples, etc. to use exported Arc alias
- add full build & test CI jobs to try build & test with `--cfg unstable_portable_atomic_arc`