### PR TITLE
DRAFT RFC: switch to using new portable-atomic feature name - DRAFT DO NOT MERGE

### DIFF
--- a/.github/workflows/portable-rustls-ci-build.yml
+++ b/.github/workflows/portable-rustls-ci-build.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    name: build with unstable_portable_atomic_arc
+    name: build with portable-atomic feature
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -65,10 +65,10 @@ jobs:
           cargo add portable-atomic -F critical-section -p ${{ env.MAIN_CRATE }}
 
       - name: cargo build (debug; no-std) # (with no built-in provider)
-        run: cargo build --target ${{ matrix.target }}
+        run: cargo build -F portable-atomic --target ${{ matrix.target }}
         working-directory: rustls
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
 
       # NOTE: BUILD with hashbrown FAILS with no atomic ptr - MISSING SUPPORT in default hasher
       # - name: cargo build (debug; no-std; hashbrown) # (with no built-in provider)
@@ -77,7 +77,7 @@ jobs:
   test:
     # GENERAL NOTE: NO CI TESTING for no-std
     # (CI TESTING with no-std & with no atomic ptr FOR FUTURE CONSIDERATION)
-    name: test with unstable_portable_atomic_arc
+    name: test with portable-atomic feature
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -103,10 +103,10 @@ jobs:
           toolchain: ${{ matrix.rust }}
 
       - name: cargo test (debug; std) # no built-in provider
-        run: cargo test --features std
+        run: cargo test --features std,portable-atomic
         working-directory: rustls
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
 
       # TODO test with all features
       # - name: cargo test (debug; all features)
@@ -114,7 +114,7 @@ jobs:
       #   ...
 
   cross-build:
-    name: cross build test with unstable_portable_atomic_arc
+    name: cross build test with portable-atomic feature
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'merge_group'
     strategy:
@@ -158,14 +158,14 @@ jobs:
         run: |
           cargo add once_cell -F portable-atomic -p ${{ env.MAIN_CRATE }}
           cargo add portable-atomic -F critical-section -p ${{ env.MAIN_CRATE }}
-      - run: cross build --package ${{ env.MAIN_CRATE }} --target ${{ matrix.target }}
+      - run: cross build -F portable-atomic --package ${{ env.MAIN_CRATE }} --target ${{ matrix.target }}
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
 
   cross-test:
     # GENERAL NOTE: NO CI TESTING for no-std
     # (CI TESTING with no-std & with no atomic ptr FOR FUTURE CONSIDERATION)
-    name: cross-target testing with unstable_portable_atomic_arc
+    name: cross-target testing with portable-atomic feature
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'merge_group'
     strategy:
@@ -207,9 +207,9 @@ jobs:
         # TODO: improve performance installing bindgen with caching - see recent RUSTLS update:
         # - https://github.com/rustls/rustls/pull/2343
         run: cargo add --dev --features bindgen 'aws-lc-sys@>0.20' --package ${{ env.MAIN_CRATE }} --verbose && cargo install bindgen-cli --verbose
-      - run: cross test --package ${{ env.MAIN_CRATE }} --target ${{ matrix.target }}
+      - run: cross test -F portable-atomic --package ${{ env.MAIN_CRATE }} --target ${{ matrix.target }}
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
       - run: cross test --all-features --package ${{ env.MAIN_CRATE }} --target ${{ matrix.target }}
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,6 +1916,9 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -15,7 +15,11 @@ exclude = ["src/testdata", "tests/**"]
 build = "build.rs"
 
 [features]
+# XXX TBD INCLUDE portable-atomic - ???
 default = []
+
+# XXX TODO UPDATE DOC
+portable-atomic = ["once_cell/portable-atomic"]
 
 aws-lc-rs = ["aws_lc_rs"] # ALIAS - FAVORED OVER `aws_lc_rs` FEATURE NAME IN THIS FORK
 aws_lc_rs = ["dep:aws-lc-rs", "webpki/aws_lc_rs"]

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -465,10 +465,10 @@ mod test_macros;
 /// of rustls targetting architectures without atomic pointers to replace the implementation
 /// with another implementation such as `portable_atomic_util::Arc` in one central location.
 mod sync {
-    #[cfg(unstable_portable_atomic_arc)]
+    #[cfg(feature = "portable-atomic")]
     #[allow(clippy::disallowed_types)]
     pub(crate) type Arc<T> = portable_atomic_util::Arc<T>;
-    #[cfg(not(unstable_portable_atomic_arc))]
+    #[cfg(not(feature = "portable-atomic"))]
     #[allow(clippy::disallowed_types)]
     pub(crate) type Arc<T> = alloc::sync::Arc<T>;
 }


### PR DESCRIPTION
__STATUS:__ Likely to be deferred in favor of PR #49

__GENERAL RATIONALE__

Should (hopefully) improve experience with installing & using this fork for targets with no atomic ptr

__MAJOR TODO ITEMS__

- [ ] update documentation
- [ ] check CI build status