### PR TITLE
[portable-rustls] FIXUP DEPEDENCIES & DOC for targets with no atomic ptr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ log = { version = "0.4.8" }
 macro_rules_attribute = "0.2"
 mio = { version = "1", features = ["net", "os-poll"] }
 num-bigint = "0.4.4"
-once_cell = { version = "1.16", default-features = false, features = ["alloc", "race"] }
+once_cell = { version = "1.20.3", default-features = false, features = ["alloc", "race"] }
 openssl = "0.10"
 p256 = { version = "0.13.2", default-features = false, features = ["alloc", "ecdsa", "pkcs8"] }
 pkcs8 = "0.10.2"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ THIS FORK SUPPORTS using `Arc` from `portable-atomic-util` to support targets wi
 <!-- TODO: IMPROVE & CLEAN UP DOCUMENTATION FOR THIS; ADD CARGO FEATURE(S) TO HELP AUTOMATE THIS STEP -->
 WHEN BUILDING FOR A TARGET WITH NO ATOMIC PTR, NEED TO ADD THE FOLLOWING DEPENDENCIES WITH SPECIFIC FEATURES ENABLED:
 - add `once_cell` with `portable-atomic` feature enabled
-- `portable-atomic` with `critical-section` or `unsafe-assume-single-core` feature enabled - see the following for more info & requirements: <https://docs.rs/critical-section/latest/critical_section/#usage-in-no-std-binaries>
+- add `portable-atomic` with `critical-section` or `unsafe-assume-single-core` feature enabled - see the following for more info & requirements: <https://docs.rs/portable-atomic/latest/portable_atomic/#optional-features>
+- possibly more requirements in case of `portable-atomic` with `critical-section` for no-std: <https://docs.rs/critical-section/latest/critical_section/#usage-in-no-std-binaries>
 
 <!-- TODO: ADDRESS HOW TO BUILD WITH A CRYPTO PROVIDER ON A TARGET WITH NO ATOMIC PTR -->
 <!-- (MAYBE BUILD WITH A BUILT-IN CRYPTO PROVIDER OR MAYBE THIRD-PARTY CRYPTO PROVIDER) -->

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -39,11 +39,18 @@ brotli = { workspace = true, optional = true }
 brotli-decompressor = { workspace = true, optional = true }
 hashbrown = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
-# only required for no-std - RECENT VERSION NEEDED IN THIS FORK TO AVOID ANY
-# POTENTIAL ISSUES WITH `critical-section` feature for no atomic ptr support
+# REQUIRED for no-std (with recent update to avoid any potential surprises with no atomic ptr support, etc.)
+# NOTE: While it would be possible to use `once_cell` with `critical-section` feature,
+# which would enable using `once_cell::sync::OnceCell` instead of `once_cell::race::OnceBox`,
+# this does not seem to have so much benefit as the likelihood of multiple threads attempting
+# to set the default crypto provider at the same time seems extremely low.
+# Using `once_cell::sync::OnceCell` would let the losing thread to see the winning value
+# in the error result from `crypto::CryptoProvider::set_default()`, which does not seem
+# worth using the `critical-section` feature with its no-std installation requirements.
+# TODO: specify `once_cell` version in single place - see also: https://github.com/rustls/rustls/pull/2350
 once_cell = { version = "1.20.3", default-features = false, features = ["alloc", "race"] }
-# TODO SHOULD BE OPTIONAL WITH FEATURE CONFIG IN THIS FORK
-portable-atomic-util = { version = "0.2.4", features = ["alloc"] }
+# TODO: KEEP `portable-atomic-util` OPTIONAL WITH FEATURE CONFIG IN THIS FORK
+portable-atomic-util = { version = "0.2.4", default-features = false, features = ["alloc"] }
 ring = { workspace = true, optional = true }
 subtle = { workspace = true }
 webpki = { workspace = true }

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -19,7 +19,8 @@
 //! <!-- TODO: IMPROVE & CLEAN UP DOCUMENTATION FOR THIS; ADD CARGO FEATURE(S) TO HELP AUTOMATE THIS STEP -->
 //! WHEN BUILDING FOR A TARGET WITH NO ATOMIC PTR, NEED TO ADD THE FOLLOWING DEPENDENCIES WITH SPECIFIC FEATURES ENABLED:
 //! - add `once_cell` with `portable-atomic` feature enabled
-//! - `portable-atomic` with `critical-section` or `unsafe-assume-single-core` feature enabled - see the following for more info & requirements: <https://docs.rs/critical-section/latest/critical_section/#usage-in-no-std-binaries>
+//! - add `portable-atomic` with `critical-section` or `unsafe-assume-single-core` feature enabled - see the following for more info & requirements: <https://docs.rs/portable-atomic/latest/portable_atomic/#optional-features>
+//! - possibly more requirements in case of `portable-atomic` with `critical-section` for no-std: <https://docs.rs/critical-section/latest/critical_section/#usage-in-no-std-binaries>
 //!
 //! <!-- TODO: ADDRESS HOW TO BUILD WITH A CRYPTO PROVIDER ON A TARGET WITH NO ATOMIC PTR -->
 //! <!-- (MAYBE BUILD WITH A BUILT-IN CRYPTO PROVIDER OR MAYBE THIRD-PARTY CRYPTO PROVIDER) -->


### PR DESCRIPTION
__DESCRIPTION__

```
motivation:

- using `default-features = false` is generally best practice for library crates
- existing comments for `once_cell` were a little outdated with a recent change
- need some comments to note motivation for using `once_cell` with
  `once_cell::race::OnceBox` for no-std rather than using `once_cell`
  with nicer `once_cell::sync::OnceCell` API
- documentation needs reference to info:
  - https://docs.rs/portable-atomic/latest/portable_atomic/#optional-features
- other minor updates needed

---

PR ref: https://github.com/brody4hire/portable-rustls/pull/46
```