### PR TITLE
[portable-rustls] FIXUP CLIPPY UPDATES FOR disallowed-types

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -2,6 +2,7 @@ upper-case-acronyms-aggressive = true
 
 # only intended to affect main rustls crate - need to allow disallowed-types in all other crates in Clippy CI job
 disallowed-types = [
-  { path = "portable_atomic_ptr::Arc", reason = "must use Arc from sync module to support configuration of Arc implementation used in this fork" },
+  { path = "portable_atomic_util::Arc", reason = "must use Arc from sync module to support configuration of Arc implementation used in this fork" },
+  { path = "alloc::sync::Arc", reason = "must use Arc from sync module to support downstream forks targetting architectures without atomic ptrs" },
   { path = "std::sync::Arc", reason = "must use Arc from sync module to support downstream forks targetting architectures without atomic ptrs" },
 ]


### PR DESCRIPTION
- FIXUP path value for: `path = "portable_atomic_util::Arc"`
- ADD PATH VALUE REQUIRED FOR no-std: `path = "alloc::sync::Arc"`

---

incorrect Clippy config was introduced in PR #17