### PR TITLE
[portable-rustls] update to use portable_atomic_util::Arc by default (etc.)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ env:
   # NOTE: `portable-rustls` fork name is REPEATED here in env - TODO avoid repeating if possible
   ALL_FEATURES_EXCEPT_UNSAFE: $(admin/all-features-except unsafe-assume-single-core portable-rustls)
   MAIN_CRATE: portable-rustls
+  # WITH QUICK WORKAROUND USING UNSTABLE CFG OPTION TO SIMPLIFY RUNNING MANY EXISTING CI JOBS
+  # TODO: UPDATE EXISTING CI JOBS TO WORK WITHOUT THE UNSTABLE CFG OPTION, IN A SIMILAR FASHION TO:
+  # - https://github.com/brody4hire/portable-rustls/pull/52
+  RUSTFLAGS: --cfg unstable_use_arc_from_stdlib
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,6 +31,8 @@ jobs:
   build:
     name: Build+test
     runs-on: ${{ matrix.os }}
+    # TODO: UPDATE THIS CI JOB TO WORK WITH & WITHOUT UNSTABLE CFG OPTION, IN A SIMILAR FASHION TO:
+    # - https://github.com/brody4hire/portable-rustls/pull/52
     strategy:
       matrix:
         rust:
@@ -320,7 +326,9 @@ jobs:
       - name: Run micro-benchmarks
         run: cargo bench --locked ${{ env.ALL_FEATURES_EXCEPT_UNSAFE }}
         env:
-          RUSTFLAGS: --cfg=bench
+          # TODO: UPDATE TO WORK WITHOUT THE UNSTABLE CFG OPTION, IN A SIMILAR FASHION TO:
+          # - https://github.com/brody4hire/portable-rustls/pull/52
+          RUSTFLAGS: --cfg=bench --cfg=unstable_use_arc_from_stdlib
 
   docs:
     name: Check for documentation errors

--- a/.github/workflows/portable-rustls-ci-build.yml
+++ b/.github/workflows/portable-rustls-ci-build.yml
@@ -25,8 +25,11 @@ concurrency:
 
 jobs:
   build:
-    name: build with unstable_portable_atomic_arc
+    name: build with default Arc alias
     runs-on: ${{ matrix.os }}
+    env:
+      # AS NEEDED for default build (with default Arc alias to portable_atomic_util::Arc)
+      RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
     strategy:
       matrix:
         rust:
@@ -63,16 +66,12 @@ jobs:
       - name: cargo build (debug; no-std; critical-section) # (with no built-in provider)
         run: cargo build -F critical-section --target ${{ matrix.target }}
         working-directory: rustls
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
       - name: cargo build (debug; no-std; unsafe-assume-single-core) # (with no built-in provider)
         # TODO: UPDATE to match in case of any more target(s) are added with no atomic ptr
         if: startsWith(matrix.target, 'riscv') || startsWith(matrix.target, 'thumbv6')
         run: cargo build -F unsafe-assume-single-core --target ${{ matrix.target }}
         working-directory: rustls
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
       # NOTE: BUILD with hashbrown FAILS with no atomic ptr - MISSING SUPPORT in default hasher
       # - name: cargo build (debug; no-std; hashbrown) # (with no built-in provider)
@@ -81,8 +80,11 @@ jobs:
   test:
     # GENERAL NOTE: NO CI TESTING for no-std
     # (CI TESTING with no-std & with no atomic ptr FOR FUTURE CONSIDERATION)
-    name: test with unstable_portable_atomic_arc
+    name: test with default Arc alias
     runs-on: ${{ matrix.os }}
+    env:
+      # AS NEEDED for default build (with default Arc alias to portable_atomic_util::Arc)
+      RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
     strategy:
       matrix:
         rust:
@@ -112,8 +114,6 @@ jobs:
       - name: cargo test (debug; std) # no built-in provider
         run: cargo test --features std
         working-directory: rustls
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
       - name: cargo test (debug; unstable-api-all [should cover most if not all non-unsafe features])
         # QUICK WORKAROUND to avoid test issue with Rust nightly-2024-05-...
@@ -128,13 +128,14 @@ jobs:
         if: ${{ !startsWith(matrix.rust, 'nightly-2024-05-') }}
         run: cargo test ${{ env.ALL_FEATURES_EXCEPT_UNSAFE }}
         working-directory: rustls
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
   cross-build:
-    name: cross build test with unstable_portable_atomic_arc
+    name: cross build test with default Arc alias
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'merge_group'
+    env:
+      # AS NEEDED for default build (with default Arc alias to portable_atomic_util::Arc)
+      RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
     strategy:
       matrix:
         rust:
@@ -172,23 +173,19 @@ jobs:
       - name: Install cross (cross-rs) from GitHub
         run: cargo install cross --git https://github.com/cross-rs/cross
       - run: cross build --package ${{ env.MAIN_CRATE }} -F critical-section --target ${{ matrix.target }}
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
       - run: cross build --package ${{ env.MAIN_CRATE }} -F unsafe-assume-single-core --target ${{ matrix.target }}
         # TODO: UPDATE to match in case of any more target(s) are added with no atomic ptr
         if: startsWith(matrix.target, 'thumbv6')
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
   cross-test:
     # GENERAL NOTE: NO CI TESTING for no-std
     # (CI TESTING with no-std & with no atomic ptr FOR FUTURE CONSIDERATION)
-    name: cross-target testing with unstable_portable_atomic_arc
+    name: cross-target testing with default Arc alias
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'merge_group'
-    # TODO env with RUSTFLAGS in a similar fashion for other CI jobs - avoid repeating in many CI jobs steps
     env:
-      RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+      # AS NEEDED for default build (with default Arc alias to portable_atomic_util::Arc)
+      RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
     strategy:
       matrix:
         rust:
@@ -237,6 +234,9 @@ jobs:
     # (with help from exported `Arc` alias)
     name: full build with unstable_portable_atomic_arc cfg
     runs-on: ${{ matrix.os }}
+    env:
+      # AS NEEDED for default build (with default Arc alias to portable_atomic_util::Arc)
+      RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
     strategy:
       matrix:
         rust:
@@ -269,21 +269,20 @@ jobs:
 
       - name: cargo build (debug; no-std) # (with no built-in provider)
         run: cargo build
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
       - name: cargo build (debug; std; all features except unsafe-assume-single-core)
         # QUICK WORKAROUND TO AVOID BUILD ISSUE WITH RUST NIGHTLY FROM OCTOBER 2023
         if: ${{ !startsWith(matrix.rust, 'nightly-2023-10') }}
         run: cargo build ${{ env.ALL_FEATURES_EXCEPT_UNSAFE }}
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
   full-test:
     # test everything builds together with this build cfg option enabled
     # (with help from exported `Arc` alias)
     name: full test with unstable_portable_atomic_arc cfg
     runs-on: ${{ matrix.os }}
+    env:
+      # AS NEEDED for default build (with default Arc alias to portable_atomic_util::Arc)
+      RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
     strategy:
       matrix:
         rust:
@@ -310,20 +309,12 @@ jobs:
 
       - name: cargo test (debug; no-std) # (with no built-in provider)
         run: cargo test
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
       - name: cargo test (debug; std; all features except unsafe-assume-single-core)
         run: cargo test ${{ env.ALL_FEATURES_EXCEPT_UNSAFE }}
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
       - name: cargo test (debug; rustls-provider-example; all features)
         run: cargo test --all-features -p rustls-provider-example
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
 
       - name: cargo test (debug; rustls-provider-test; all features)
         run: cargo test --all-features -p rustls-provider-test
-        env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc

--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ Rustls is a modern TLS library written in Rust.
 <!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
 __IMPORTANT NOTICE:__ regardless of upstream __`rustls`__ project this fork is __NOT CERTIFIED__ and __NOT PEER-REVIEWED__ - USE AT YOUR OWN RISK (as stated further below)
 
-<!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
+<!-- TODO(portable-rustls) CLEANUP & IMPROVE DOC FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
+REQUIREMENTS FOR BUILDING WITH THIS FORK (as stated with more details further below):
+
+>- Use Rust nightly toolchain
+>- Use `RUSTFLAGS` with `--cfg portable_atomic_unstable_coerce_unsized` during `cargo build` (etc.) as needed for `portable-atomic-util`
+>- in case of no-std: add `portable-atomic` with `critical-section` or `unsafe-assume-single-core` feature enabled - see the following for more info & requirements: <https://docs.rs/portable-atomic/latest/portable_atomic/#optional-features>
+
+<!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE(S) FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
 RECOMMENDED USAGE OF THIS FORK (as stated further below):
 
 <!-- NOTE: SHOULD KEEP THIS BLOCK QUOTATION IN SYNC WITH INFO FURTHER BELOW -->
@@ -96,11 +103,11 @@ Then import and use __`rustls`__ in the code as usual.
 (Unlike the original __`rustls`__, NO CRATE FEATURES are enabled by default in this fork.)
 
 <!-- TODO: [...][crate::Arc] pattern is replaced by `admin/pull-readme` - TODO REFERENCE docs.rs when possible -->
-Note that this fork provides a crate-level `Arc` type alias to help use the correct `Arc` type according to the build configuration:
+Note that this fork provides a crate-level `Arc` type alias to help use the correct `Arc` type (according to the build configuration):
 
-- alias to [`portable_atomic_util::Arc`](https://docs.rs/portable-atomic-util/latest/portable_atomic_util/struct.Arc.html),
-if `RUSTFLAGS` is set with `--cfg unstable_portable_atomic_arc` during Cargo build
-- otherwise alias to [`alloc::sync::Arc`](https://doc.rust-lang.org/nightly/alloc/sync/struct.Arc.html) / [`std::sync::Arc`](https://doc.rust-lang.org/nightly/std/sync/struct.Arc.html)
+- alias to [`portable_atomic_util::Arc`](https://docs.rs/portable-atomic-util/latest/portable_atomic_util/struct.Arc.html), by default build configuration - supports targets with no atomic ptr
+- alias to [`alloc::sync::Arc`](https://doc.rust-lang.org/nightly/alloc/sync/struct.Arc.html) / [`std::sync::Arc`](https://doc.rust-lang.org/nightly/std/sync/struct.Arc.html),
+if enabled by crate cfg option as documented further below (not actively maintained)
 
 It is recommended to simply import the crate-level `Arc` type alias from this crate:
 
@@ -109,14 +116,6 @@ use rustls::Arc;
 ```
 
 ### targets with no atomic ptr
-
-This fork supports using `Arc` from `portable-atomic-util` to support targets with no atomic ptr, with the following requirements:
-
-Must use Rust nightly toolchain.
-
-Must use the following cfg flags in `RUSTFLAGS` FOR `cargo build` (etc.):
-- `--cfg portable_atomic_unstable_coerce_unsized`
-- `--cfg unstable_portable_atomic_arc`
 
 <!-- TODO: IMPROVE & CLEAN UP DOCUMENTATION FOR THIS; ADD CARGO FEATURE(S) TO HELP AUTOMATE THIS STEP -->
 When building for a target with no atomic ptr, enable exactly one of the following crate features:

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -177,6 +177,9 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "portable-atomic"

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -61,7 +61,12 @@ zlib = ["dep:zlib-rs"]
 
 # FEATURES to help build for no-std targets with no atomic ptr - see documentation for more info
 critical-section = ["dep:portable-atomic", "once_cell/portable-atomic", "portable-atomic/critical-section"]
-unsafe-assume-single-core = ["once_cell/portable-atomic", "portable-atomic/unsafe-assume-single-core"]
+# XXX TODO MERGE FROM OTHER UPDATE:
+unsafe-assume-single-core = [
+  "dep:portable-atomic",
+  "once_cell/portable-atomic",
+  "portable-atomic/unsafe-assume-single-core",
+]
 
 [build-dependencies]
 rustversion = { version = "1.0.6", optional = true }
@@ -81,9 +86,9 @@ log = { workspace = true, optional = true }
 # in the error result from `crypto::CryptoProvider::set_default()`, which does not seem
 # worth using the `critical-section` feature with its no-std installation requirements.
 # TODO: specify `once_cell` version in single place - as RECENTLY UPDATED in upstream RUSTLS
-# (It may be best to specify the `once_cell` features here, as may be needed for updates moving forward.)
-once_cell = { version = "1.20.3", default-features = false, features = ["alloc", "race"] }
-# EXPLICIT `portable-atomic` dependency REQUIRED for `unsafe-assume-single-core` feature
+# (keeping `once_cell` features list here, with features as needed by this main crate)
+once_cell = { version = "1.20.3", default-features = false, features = ["alloc", "portable-atomic", "race"] }
+# EXPLICIT `portable-atomic` dependency REQUIRED BY BOTH  `critical-section` & `unsafe-assume-single-core` features
 portable-atomic = { version = "1.11", default-features = false, optional = true }
 # TODO: KEEP `portable-atomic-util` OPTIONAL WITH FEATURE CONFIG IN THIS FORK
 portable-atomic-util = { version = "0.2.4", default-features = false, features = ["alloc"] }
@@ -167,6 +172,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
   # ---
+  "portable_atomic_util::arc::Arc",
   "rustls_pki_types",
   "rustls_pki_types::*",
 ]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -60,11 +60,19 @@ tls12 = []
 zlib = ["dep:zlib-rs"]
 
 # FEATURES to help build for no-std targets with no atomic ptr - see documentation for more info
-critical-section = ["dep:portable-atomic", "once_cell/portable-atomic", "portable-atomic/critical-section"]
-# XXX TODO MERGE FROM OTHER UPDATE:
-unsafe-assume-single-core = [
+critical-section = [
+  # XXX TBD ??? ??? ???
   "dep:portable-atomic",
-  "once_cell/portable-atomic",
+  # XXX TBD ??? ???
+  # "once_cell/portable-atomic",
+  "portable-atomic/critical-section",
+]
+# XXX TODO REMOVE ENTRIES NO LONGER NEEDED & CLEANUP:
+unsafe-assume-single-core = [
+  # XXX TBD ??? ???
+  "dep:portable-atomic",
+  # XXX TBD ??? ???
+  # "once_cell/portable-atomic",
   "portable-atomic/unsafe-assume-single-core",
 ]
 
@@ -85,9 +93,17 @@ log = { workspace = true, optional = true }
 # Using `once_cell::sync::OnceCell` would let the losing thread to see the winning value
 # in the error result from `crypto::CryptoProvider::set_default()`, which does not seem
 # worth using the `critical-section` feature with its no-std installation requirements.
-# TODO: specify `once_cell` version in single place - as RECENTLY UPDATED in upstream RUSTLS
-# (keeping `once_cell` features list here, with features as needed by this main crate)
-once_cell = { version = "1.20.3", default-features = false, features = ["alloc", "portable-atomic", "race"] }
+# XXX TBD ??? ??? ???:
+# INHERITS VERSION FROM XXX XXX
+# WITH `once_cell` features UPDATED FOR THIS FORK
+once_cell = { workspace = true, default-features = false, features = [
+  # XXX TBD ADDITIONAL COMMENT HERE ??? ??? ???
+  "alloc",
+  # XXX TBD AS NEEDED FOR XXX XXX XXX
+  "portable-atomic",
+  "race",
+] }
+# XXX TBD SHOULD THIS BE AN OPTIONAL DEPENDENCY OR NOT - ???
 # EXPLICIT `portable-atomic` dependency REQUIRED BY BOTH  `critical-section` & `unsafe-assume-single-core` features
 portable-atomic = { version = "1.11", default-features = false, optional = true }
 # TODO: KEEP `portable-atomic-util` OPTIONAL WITH FEATURE CONFIG IN THIS FORK

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -60,13 +60,8 @@ tls12 = []
 zlib = ["dep:zlib-rs"]
 
 # FEATURES to help build for no-std targets with no atomic ptr - see documentation for more info
-critical-section = ["dep:portable-atomic", "once_cell/portable-atomic", "portable-atomic/critical-section"]
-# XXX TODO MERGE FROM OTHER UPDATE:
-unsafe-assume-single-core = [
-  "dep:portable-atomic",
-  "once_cell/portable-atomic",
-  "portable-atomic/unsafe-assume-single-core",
-]
+critical-section = ["dep:portable-atomic", "portable-atomic/critical-section"]
+unsafe-assume-single-core = ["dep:portable-atomic", "portable-atomic/unsafe-assume-single-core"]
 
 [build-dependencies]
 rustversion = { version = "1.0.6", optional = true }
@@ -86,7 +81,7 @@ log = { workspace = true, optional = true }
 # in the error result from `crypto::CryptoProvider::set_default()`, which does not seem
 # worth using the `critical-section` feature with its no-std installation requirements.
 # TODO: specify `once_cell` version in single place - as RECENTLY UPDATED in upstream RUSTLS
-# (keeping `once_cell` features list here, with features as needed by this main crate)
+# (keeping `once_cell` features list here, with UPDATED FEATURES as needed by this main crate)
 once_cell = { version = "1.20.3", default-features = false, features = ["alloc", "portable-atomic", "race"] }
 # EXPLICIT `portable-atomic` dependency REQUIRED BY BOTH  `critical-section` & `unsafe-assume-single-core` features
 portable-atomic = { version = "1.11", default-features = false, optional = true }

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -60,19 +60,11 @@ tls12 = []
 zlib = ["dep:zlib-rs"]
 
 # FEATURES to help build for no-std targets with no atomic ptr - see documentation for more info
-critical-section = [
-  # XXX TBD ??? ??? ???
-  "dep:portable-atomic",
-  # XXX TBD ??? ???
-  # "once_cell/portable-atomic",
-  "portable-atomic/critical-section",
-]
-# XXX TODO REMOVE ENTRIES NO LONGER NEEDED & CLEANUP:
+critical-section = ["dep:portable-atomic", "once_cell/portable-atomic", "portable-atomic/critical-section"]
+# XXX TODO MERGE FROM OTHER UPDATE:
 unsafe-assume-single-core = [
-  # XXX TBD ??? ???
   "dep:portable-atomic",
-  # XXX TBD ??? ???
-  # "once_cell/portable-atomic",
+  "once_cell/portable-atomic",
   "portable-atomic/unsafe-assume-single-core",
 ]
 
@@ -93,17 +85,9 @@ log = { workspace = true, optional = true }
 # Using `once_cell::sync::OnceCell` would let the losing thread to see the winning value
 # in the error result from `crypto::CryptoProvider::set_default()`, which does not seem
 # worth using the `critical-section` feature with its no-std installation requirements.
-# XXX TBD ??? ??? ???:
-# INHERITS VERSION FROM XXX XXX
-# WITH `once_cell` features UPDATED FOR THIS FORK
-once_cell = { workspace = true, default-features = false, features = [
-  # XXX TBD ADDITIONAL COMMENT HERE ??? ??? ???
-  "alloc",
-  # XXX TBD AS NEEDED FOR XXX XXX XXX
-  "portable-atomic",
-  "race",
-] }
-# XXX TBD SHOULD THIS BE AN OPTIONAL DEPENDENCY OR NOT - ???
+# TODO: specify `once_cell` version in single place - as RECENTLY UPDATED in upstream RUSTLS
+# (keeping `once_cell` features list here, with features as needed by this main crate)
+once_cell = { version = "1.20.3", default-features = false, features = ["alloc", "portable-atomic", "race"] }
 # EXPLICIT `portable-atomic` dependency REQUIRED BY BOTH  `critical-section` & `unsafe-assume-single-core` features
 portable-atomic = { version = "1.11", default-features = false, optional = true }
 # TODO: KEEP `portable-atomic-util` OPTIONAL WITH FEATURE CONFIG IN THIS FORK

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -21,11 +21,11 @@
 //! (Unlike the original __`rustls`__, NO CRATE FEATURES are enabled by default in this fork.)
 //!
 //! <!-- TODO: [...][crate::Arc] pattern is replaced by `admin/pull-readme` - TODO REFERENCE docs.rs when possible -->
-//! Note that this fork provides a crate-level [`Arc` type alias][crate::Arc] to help use the correct `Arc` type according to the build configuration:
+//! Note that this fork provides a crate-level [`Arc` type alias][crate::Arc] to help use the correct `Arc` type (according to the build configuration):
 //!
-//! - alias to [`portable_atomic_util::Arc`](https://docs.rs/portable-atomic-util/latest/portable_atomic_util/struct.Arc.html),
-//!   if `RUSTFLAGS` is set with `--cfg unstable_portable_atomic_arc` during Cargo build
-//! - otherwise alias to [`alloc::sync::Arc`](https://doc.rust-lang.org/nightly/alloc/sync/struct.Arc.html) / [`std::sync::Arc`](https://doc.rust-lang.org/nightly/std/sync/struct.Arc.html)
+//! - alias to [`portable_atomic_util::Arc`](https://docs.rs/portable-atomic-util/latest/portable_atomic_util/struct.Arc.html), by default build configuration - supports targets with no atomic ptr
+//! - alias to [`alloc::sync::Arc`](https://doc.rust-lang.org/nightly/alloc/sync/struct.Arc.html) / [`std::sync::Arc`](https://doc.rust-lang.org/nightly/std/sync/struct.Arc.html),
+//!   if enabled by crate cfg option as documented further below (not actively maintained)
 //!
 //! It is recommended to simply import the crate-level [`Arc` type alias][crate::Arc] from this crate:
 //!
@@ -34,14 +34,6 @@
 //! ```
 //!
 //! ### targets with no atomic ptr
-//!
-//! This fork supports using `Arc` from `portable-atomic-util` to support targets with no atomic ptr, with the following requirements:
-//!
-//! Must use Rust nightly toolchain.
-//!
-//! Must use the following cfg flags in `RUSTFLAGS` FOR `cargo build` (etc.):
-//! - `--cfg portable_atomic_unstable_coerce_unsized`
-//! - `--cfg unstable_portable_atomic_arc`
 //!
 //! <!-- TODO: IMPROVE & CLEAN UP DOCUMENTATION FOR THIS; ADD CARGO FEATURE(S) TO HELP AUTOMATE THIS STEP -->
 //! When building for a target with no atomic ptr, enable exactly one of the following crate features:
@@ -438,9 +430,9 @@
 //!
 //! ## Crate cfg options
 //!
-//! - `unstable_portable_atomic_arc` - configures this fork to use `Arc` from `portable_atomic_util` instead
-//!   of `std::sync::Arc` - requires Rust nightly together with `portable_atomic_unstable_coerce_unsized`
-//!   to build successfully.
+//! - `unstable_use_arc_from_stdlib` - configures this fork to use `Arc` from `alloc::sync` instead of `portable-atomic-util`;
+//!   may be possible to build with Rust stable or nightly; this option is not actively maintained
+//!   (primarily added for CI testing purposes)
 //!
 //! [x25519mlkem768-manual]: manual::_05_defaults#about-the-post-quantum-secure-key-exchange-x25519mlkem768
 
@@ -480,7 +472,7 @@
     clippy::single_component_path_imports,
     clippy::new_without_default
 )]
-// QUICK CLIPPY WORKAROUND for `unstable_portable_atomic_arc` IN THIS FORK
+// QUICK CLIPPY WORKAROUND for `unstable_use_arc_from_stdlib` IN THIS FORK
 #![allow(unexpected_cfgs)]
 // Enable documentation for all features on docs.rs
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
@@ -561,10 +553,13 @@ mod sync {
 /// Keeping the extra level of indirection with this separate internal module so that
 /// the generated doc shows use of exported Arc alias from this crate.
 mod arc_type_alias {
-    #[cfg(unstable_portable_atomic_arc)]
+    // NOTE that unstable_use_arc_from_stdlib option is NOT WELL DOCUMENTED and NOT MAINTAINED;
+    // primary purpose is for extra CI testing
+    // (may update to test more extensively with multiple options & potentially with alloc::rc::Rc as well)
+    #[cfg(not(unstable_use_arc_from_stdlib))]
     #[allow(clippy::disallowed_types)]
     pub(crate) type Arc<T> = portable_atomic_util::Arc<T>;
-    #[cfg(not(unstable_portable_atomic_arc))]
+    #[cfg(unstable_use_arc_from_stdlib)]
     #[allow(clippy::disallowed_types)]
     pub(crate) type Arc<T> = alloc::sync::Arc<T>;
 }

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 #![allow(clippy::duplicate_mod)]
-// QUICK CLIPPY WORKAROUND for `unstable_portable_atomic_arc` IN THIS FORK
+// QUICK CLIPPY WORKAROUND for `unstable_use_arc_from_stdlib` IN THIS FORK
 #![allow(unexpected_cfgs)]
 
 use std::io;


### PR DESCRIPTION
__UPDATED COMMIT MESSAGE WITH DESCRIPTION__

```
[portable-rustls] update to use portable_atomic_util::Arc by default (etc.)

---

PR ref: https://github.com/brody4hire/portable-rustls/pull/49
```

__UPDATED STATUS__

- this is a quicker alternative to more extensive proposal in PR #45 (which may be considered in some form in the future)
- testing updates as needed from PR #51 are already merged into default main branch ✅
- updates from other PR #44 - export Arc alias are now rolled into this update ✅

__GENERAL TODO ITEMS__

- [x] ~~includes updates from other PR #44 - need to merge that PR first then rebase this PR~~ - ✅
- [x] ~~push update into default main branch once CI build looks OK: d8d560f~~ - ✅
- [ ] address review comments
- [ ] resolve or defer XXX todo items in these updates
- [ ] check CI build status
- [ ] check `cargo hack check` in daily tests