### PR TITLE
[portable-rustls] EXPERIMENTAL DRAFT UPDATE: multiple Arc cfg options - INTENDED FOR TESTING PURPOSES

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,25 +28,25 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
-          - beta
           - nightly
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        rust-flags:
+          # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+          - --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
+        include:
+          - rust: stable
+            # AS NEEDED for Rust stable
+            rust-flags: --cfg=unstable_use_arc_from_stdlib
+            os: macos-latest
+          - rust: beta
+            # AS NEEDED for Rust beta
+            rust-flags: --cfg=unstable_use_arc_from_stdlib
+            os: macos-latest
         exclude:
-          # ONLY Rust nightly on Ubuntu in this fork - help save CI testing resources
-          - os: ubuntu-latest
-            rust: stable
-          - os: ubuntu-latest
-            rust: beta
-          # ONLY Rust nightly on Windows - slower platform
-          - os: windows-latest
-            rust: stable
-          - os: windows-latest
-            rust: beta
-          # and never use Windows for merge checks
+          # never use Windows for merge checks
           - os: ${{ github.event_name == 'merge_group' && 'windows-latest' }}
     steps:
       - name: Checkout sources
@@ -73,6 +73,10 @@ jobs:
 
       - name: cargo build (debug; default features)
         run: cargo build --locked
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       # N/A [FIPS REMOVED FROM THIS FORK]: nb. feature sets that include "fips" ...
       # nb. "--all-targets" does not include doctests
@@ -80,6 +84,9 @@ jobs:
         run: cargo test --release --locked --all-features --all-targets
         env:
           RUST_BACKTRACE: 1
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       # nb. this is separate since `--doc` option cannot be combined with other target option(s) ref:
       # - https://doc.rust-lang.org/cargo/commands/cargo-test.html
@@ -87,11 +94,18 @@ jobs:
         run: cargo test --release --locked --all-features --doc
         env:
           RUST_BACKTRACE: 1
+          # XXX TBD ??? ??? ???:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo test (debug; aws-lc-rs)
         run: cargo test --no-default-features --features aws_lc_rs,tls12,read_buf,logging,std --all-targets
         env:
           RUST_BACKTRACE: 1
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       # [FIPS REMOVED FROM THIS FORK]
       # - name: cargo test (release; fips)
@@ -99,26 +113,51 @@ jobs:
 
       - name: cargo build (debug; rustls-provider-example)
         run: cargo build --locked -p rustls-provider-example
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo build (debug; rustls-provider-example lib in no-std mode)
         run: cargo build --locked -p rustls-provider-example --no-default-features
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo test (debug; rustls-provider-example; all features)
         run: cargo test --all-features -p rustls-provider-example
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo build (debug; rustls-provider-test)
         run: cargo build --locked -p rustls-provider-test
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo test (debug; rustls-provider-test; all features)
         run: cargo test --all-features -p rustls-provider-test
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo package --all-features -p ${{ env.MAIN_CRATE }}
         run: cargo package --all-features -p ${{ env.MAIN_CRATE }}
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
 
   msrv:
     # NOTE: MSRV - Rust nightly is covered by multiple jobs in portable-rustls-ci-build.yml
     name: MSRV - Rust stable
     runs-on: ubuntu-latest
+    env:
+      # AS NEEDED for Rust stable
+      RUSTFLAGS: --cfg=unstable_use_arc_from_stdlib
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -149,25 +188,22 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
-          - beta
           - nightly
         os:
           - ubuntu-latest
           - macos-latest
-          # FOR FUTURE CONSIDERATION:
-          # - windows-latest
-        exclude:
-          # ONLY Rust nightly on Ubuntu in this fork - help save CI testing resources
-          - os: ubuntu-latest
-            rust: stable
-          - os: ubuntu-latest
-            rust: beta
-          # RECOMMENDED UPDATES in case this job is enabled on Windows:
-          # ONLY Rust nightly on Windows - slower platform
-          # ...
-          # and never use Windows for merge checks
-          # ...
+        rust-flags:
+          # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+          - --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
+        include:
+          - rust: stable
+            # AS NEEDED for Rust stable
+            rust-flags: --cfg=unstable_use_arc_from_stdlib
+            os: macos-latest
+          - rust: beta
+            # AS NEEDED for Rust beta
+            rust-flags: --cfg=unstable_use_arc_from_stdlib
+            os: macos-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -184,16 +220,22 @@ jobs:
       - name: cargo build (debug; default features)
         run: cargo build --locked
         working-directory: rustls
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo build (debug; no default features; no-std) with no-std target - ${{ env.NO_STD_BUILD_TARGET }}
         # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo build --locked --no-default-features --target ${{ env.NO_STD_BUILD_TARGET }}
         working-directory: rustls
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo build (debug; no default features; no-std, hashbrown) with no-std target - ${{ env.NO_STD_BUILD_TARGET }}
         # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo build --locked --no-default-features --features hashbrown --target ${{ env.NO_STD_BUILD_TARGET }}
         working-directory: rustls
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
 
       # NOTE: no features are enabled by default on main crate in this fork
       - name: cargo test (debug; default features)
@@ -201,21 +243,36 @@ jobs:
         working-directory: rustls
         env:
           RUST_BACKTRACE: 1
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo test (debug; no default features)
         # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo test --locked --no-default-features
         working-directory: rustls
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo test (debug; no default features; tls12)
         # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo test --locked --no-default-features --features tls12,std
         working-directory: rustls
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       - name: cargo test (debug; no default features; aws-lc-rs,tls12)
         # (KEEPING --no-default-features which has no effect on main crate in this fork)
         run: cargo test --no-default-features --features aws_lc_rs,tls12,std
         working-directory: rustls
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
       # [FIPS REMOVED FROM THIS FORK]
       # - name: cargo test (debug; no default features; fips,tls12)
@@ -225,18 +282,25 @@ jobs:
       - name: cargo test (release; no run)
         run: cargo test --locked --release --no-run
         working-directory: rustls
+        env:
+          RUSTFLAGS: ${{ matrix.rust-flags }}
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: ${{ matrix.rust-flags }}
 
   bogo:
     name: BoGo test suite
     runs-on: ubuntu-latest
+    env:
+      # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+      RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
 
       # [FIPS REMOVED FROM THIS FORK]
       # - name: Install golang toolchain - NO LONGER NEEDED
@@ -267,6 +331,9 @@ jobs:
   fuzz:
     name: Smoke-test fuzzing targets
     runs-on: ubuntu-latest
+    env:
+      # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+      RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -289,6 +356,9 @@ jobs:
   benchmarks:
     name: Run benchmarks
     runs-on: ubuntu-latest
+    env:
+      # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+      RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -311,11 +381,17 @@ jobs:
       - name: Run micro-benchmarks
         run: cargo bench --locked --all-features
         env:
-          RUSTFLAGS: --cfg=bench
+          # AS NEEDED for bench & build with Arc alias to portable_atomic_util::Arc
+          # XXX XXX
+          RUSTFLAGS: --cfg=bench --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
 
   docs:
     name: Check for documentation errors
     runs-on: ubuntu-latest
+    env:
+      # XXX ??? ??? ???
+      # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+      RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -328,7 +404,8 @@ jobs:
       - name: cargo doc (rustls; all features)
         run: cargo doc --locked --all-features --no-deps --document-private-items --package ${{ env.MAIN_CRATE }}
         env:
-          RUSTDOCFLAGS: -Dwarnings
+          # XXX ??? ??? ???
+          RUSTDOCFLAGS: -Dwarnings ${{ env.RUSTFLAGS }}
 
       - name: Check README.md
         run: |
@@ -343,6 +420,10 @@ jobs:
     env:
       # Favor CI testing on Rust nightly in this fork
       RUST_VERSION: nightly
+      # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+      RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
+      # XXX TBD ??? ??? ???
+      RUSTDOCFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -374,6 +455,9 @@ jobs:
   minver:
     name: Check minimum versions of direct dependencies
     runs-on: ubuntu-latest
+    env:
+      # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+      RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -395,9 +479,14 @@ jobs:
         working-directory: rustls/
 
   cross:
+    # NOTE: cross-target testing with Rust nightly toolchain & default build
+    # (with portable_atomic_util::Arc) is covered by portable-rustls-ci-build.yml
     name: cross-target testing
     runs-on: ubuntu-latest
     if: github.event_name != 'merge_group'
+    env:
+      # AS NEEDED for Rust stable
+      RUSTFLAGS: --cfg=unstable_use_arc_from_stdlib
     strategy:
       matrix:
         target:
@@ -433,6 +522,9 @@ jobs:
   semver:
     name: Check semver compatibility
     runs-on: ubuntu-latest
+    env:
+      # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+      RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -441,6 +533,9 @@ jobs:
 
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
+        env:
+          # XXX TBD ??? ???
+          RUSTDOCFLAGS: ${{ env.RUSTFLAGS }}
 
   format:
     name: Format
@@ -487,6 +582,9 @@ jobs:
   clippy:
     name: Clippy - Rust stable
     runs-on: ubuntu-latest
+    env:
+      # AS NEEDED for Rust stable
+      RUSTFLAGS: --cfg=unstable_use_arc_from_stdlib
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -511,6 +609,9 @@ jobs:
   clippy-nightly:
     name: Clippy - Rust nightly
     runs-on: ubuntu-latest
+    env:
+      # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+      RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -535,6 +636,9 @@ jobs:
   check-external-types:
     name: Validate external types appearing in public API
     runs-on: ubuntu-latest
+    env:
+      # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+      RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -543,12 +647,16 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
+          # XXX TODO UPDATE
           toolchain: nightly-2024-06-30
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
       - run: cargo install --locked cargo-check-external-types
       - name: run cargo-check-external-types for rustls/
         working-directory: rustls/
         run: cargo check-external-types
+        env:
+          # XXX TBD ??? ???
+          RUSTDOCFLAGS: ${{ env.RUSTFLAGS }}
 
   taplo:
     name: Taplo
@@ -569,14 +677,16 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: openssl-3.4.0
+      # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+      RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Cache ${{ env.VERSION }}
         uses: actions/cache@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,9 @@ on:
 
 env:
   MAIN_CRATE: portable-rustls
+  # XXX TBD ??? ???
+  # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+  RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
 
 jobs:
   generate:
@@ -44,7 +47,8 @@ jobs:
         # (CARGO DOC WITH ALL FEATURES IN THIS FORK)
         run: cargo doc --locked --all-features --no-deps --package ${{ env.MAIN_CRATE }}
         env:
-          RUSTDOCFLAGS: -Dwarnings --cfg=docsrs --html-after-content tag.html
+          # XXX TBD ??? ???
+          RUSTDOCFLAGS: -Dwarnings --cfg=docsrs ${{ env.RUSTFLAGS }} --html-after-content tag.html
 
       # [REMOVED FROM THIS FORK] Generate other pages for website (etc.)
 

--- a/.github/workflows/portable-rustls-ci-build.yml
+++ b/.github/workflows/portable-rustls-ci-build.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    name: build with unstable_portable_atomic_arc
+    name: build with default Arc alias
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -58,17 +58,22 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
 
-      # TODO: CARGO FEATURE FOR THIS STEP
-      - name: additional dependencies as needed for target(s) with no atomic ptr
-        run: |
-          cargo add once_cell -F portable-atomic -p ${{ env.MAIN_CRATE }}
-          cargo add portable-atomic -F critical-section -p ${{ env.MAIN_CRATE }}
+      # TODO: ADD CARGO FEATURE TO HELP MAKE THIS STEP A LITTLE EASIER
+      # try installing `portable-atomic` with `unsafe-assume-single-core` as a documented option,
+      # in single case of target with no atomic ptr
+      - run: cargo add portable-atomic -F unsafe-assume-single-core -p ${{ env.MAIN_CRATE }}
+        if: ${{ startsWith(matrix.target, 'riscv32') }}
+      # otherwise try installing `portable-atomic` with `critical-section` (as a documented option)
+      # in the other cases
+      - run: cargo add portable-atomic -F critical-section -p ${{ env.MAIN_CRATE }}
+        if: ${{ !startsWith(matrix.target, 'riscv32') }}
 
       - name: cargo build (debug; no-std) # (with no built-in provider)
         run: cargo build --target ${{ matrix.target }}
         working-directory: rustls
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+          RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
 
       # NOTE: BUILD with hashbrown FAILS with no atomic ptr - MISSING SUPPORT in default hasher
       # - name: cargo build (debug; no-std; hashbrown) # (with no built-in provider)
@@ -77,7 +82,7 @@ jobs:
   test:
     # GENERAL NOTE: NO CI TESTING for no-std
     # (CI TESTING with no-std & with no atomic ptr FOR FUTURE CONSIDERATION)
-    name: test with unstable_portable_atomic_arc
+    name: test with default Arc alias
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -109,7 +114,10 @@ jobs:
         run: cargo test --features std
         working-directory: rustls
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+          RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
 
       - name: cargo test (debug; all features)
         # QUICK WORKAROUND TO AVOID TEST ISSUE WITH RUST NIGHTLY FROM MAY 2024
@@ -117,11 +125,13 @@ jobs:
         run: cargo test --all-features
         working-directory: rustls
         env:
-          # AS NEEDED for default build (with default Arc alias to portable_atomic_util::Arc)
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized
+          # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+          RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
+          # XXX TBD ??? ??? ???:
+          RUSTDOCFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
 
   cross-build:
-    name: cross build test with unstable_portable_atomic_arc
+    name: cross build test with default Arc alias
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'merge_group'
     strategy:
@@ -160,19 +170,24 @@ jobs:
       # - https://github.com/rustls/rustls/pull/2343
       - name: Install cross (cross-rs) from GitHub
         run: cargo install cross --git https://github.com/cross-rs/cross
-      # TODO: CARGO FEATURE FOR THIS STEP
-      - name: additional dependencies as needed for target(s) with no atomic ptr
-        run: |
-          cargo add once_cell -F portable-atomic -p ${{ env.MAIN_CRATE }}
-          cargo add portable-atomic -F critical-section -p ${{ env.MAIN_CRATE }}
+      # TODO: ADD CARGO FEATURE TO HELP MAKE THIS STEP A LITTLE EASIER
+      # try installing `portable-atomic` with `unsafe-assume-single-core` as a documented option,
+      # in single case of target with no atomic ptr
+      - run: cargo add portable-atomic -F unsafe-assume-single-core -p ${{ env.MAIN_CRATE }}
+        if: ${{ startsWith(matrix.target, 'riscv32') }}
+      # otherwise try installing `portable-atomic` with `critical-section` (as a documented option)
+      # in the other cases
+      - run: cargo add portable-atomic -F critical-section -p ${{ env.MAIN_CRATE }}
+        if: ${{ !startsWith(matrix.target, 'riscv32') }}
       - run: cross build --package ${{ env.MAIN_CRATE }} --target ${{ matrix.target }}
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+          RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
 
   cross-test:
     # GENERAL NOTE: NO CI TESTING for no-std
     # (CI TESTING with no-std & with no atomic ptr FOR FUTURE CONSIDERATION)
-    name: cross-target testing with unstable_portable_atomic_arc
+    name: cross-target testing with default Arc alias
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'merge_group'
     strategy:
@@ -216,7 +231,9 @@ jobs:
         run: cargo add --dev --features bindgen 'aws-lc-sys@>0.20' --package ${{ env.MAIN_CRATE }} --verbose && cargo install bindgen-cli --verbose
       - run: cross test --package ${{ env.MAIN_CRATE }} --target ${{ matrix.target }}
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+          RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
       - run: cross test --all-features --package ${{ env.MAIN_CRATE }} --target ${{ matrix.target }}
         env:
-          RUSTFLAGS: --cfg portable_atomic_unstable_coerce_unsized --cfg unstable_portable_atomic_arc
+          # AS NEEDED for build with Arc alias to portable_atomic_util::Arc
+          RUSTFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc

--- a/.github/workflows/portable-rustls-ci-build.yml
+++ b/.github/workflows/portable-rustls-ci-build.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    name: build with default Arc alias
+    name: build with unstable_portable_atomic_arc
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -82,7 +82,7 @@ jobs:
   test:
     # GENERAL NOTE: NO CI TESTING for no-std
     # (CI TESTING with no-std & with no atomic ptr FOR FUTURE CONSIDERATION)
-    name: test with default Arc alias
+    name: test with unstable_portable_atomic_arc
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -131,7 +131,7 @@ jobs:
           RUSTDOCFLAGS: --cfg=portable_atomic_unstable_coerce_unsized --cfg=unstable_portable_atomic_arc
 
   cross-build:
-    name: cross build test with default Arc alias
+    name: cross build test with unstable_portable_atomic_arc
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'merge_group'
     strategy:
@@ -187,7 +187,7 @@ jobs:
   cross-test:
     # GENERAL NOTE: NO CI TESTING for no-std
     # (CI TESTING with no-std & with no atomic ptr FOR FUTURE CONSIDERATION)
-    name: cross-target testing with default Arc alias
+    name: cross-target testing with unstable_portable_atomic_arc
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'merge_group'
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,6 +1916,9 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Rustls is a modern TLS library written in Rust.
 <!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
 __IMPORTANT NOTICE:__ regardless of upstream __`rustls`__ project this fork is __NOT CERTIFIED__ and __NOT PEER-REVIEWED__ - USE AT YOUR OWN RISK (as stated further below)
 
-<!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
+<!-- TODO(portable-rustls) CLEANUP & IMPROVE DOC FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
+REQUIREMENTS FOR BUILDING WITH THIS FORK (as stated further below):
+
+>- Use Rust nightly toolchain
+>- Use `RUSTFLAGS` with `--cfg portable_atomic_unstable_coerce_unsized` during `cargo build` (etc.) as needed with `portable-atomic`
+
+<!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE(S) FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
 RECOMMENDED USAGE OF THIS FORK (as stated further below):
 
 <!-- NOTE: SHOULD KEEP THIS BLOCK QUOTATION IN SYNC WITH INFO FURTHER BELOW -->

--- a/README.md
+++ b/README.md
@@ -25,13 +25,7 @@ Rustls is a modern TLS library written in Rust.
 <!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
 __IMPORTANT NOTICE:__ regardless of upstream __`rustls`__ project this fork is __NOT CERTIFIED__ and __NOT PEER-REVIEWED__ - USE AT YOUR OWN RISK (as stated further below)
 
-<!-- TODO(portable-rustls) CLEANUP & IMPROVE DOC FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
-REQUIREMENTS FOR BUILDING WITH THIS FORK (as stated further below):
-
->- Use Rust nightly toolchain
->- Use `RUSTFLAGS` with `--cfg portable_atomic_unstable_coerce_unsized` during `cargo build` (etc.) as needed with `portable-atomic`
-
-<!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE(S) FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
+<!-- TODO(portable-rustls) CLEANUP & IMPROVE NOTE FOR THIS FORK; REWORK TO AVOID REPEATED INFO -->
 RECOMMENDED USAGE OF THIS FORK (as stated further below):
 
 <!-- NOTE: SHOULD KEEP THIS BLOCK QUOTATION IN SYNC WITH INFO FURTHER BELOW -->

--- a/bogo/src/main.rs
+++ b/bogo/src/main.rs
@@ -6,10 +6,12 @@
 
 use std::fmt::{Debug, Formatter};
 use std::io::{self, Read, Write};
-use std::sync::Arc;
 use std::{env, net, process, thread, time};
 
 use base64::prelude::{Engine, BASE64_STANDARD};
+
+use rustls::Arc;
+
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::client::{
     ClientConfig, ClientConnection, EchConfig, EchGreaseConfig, EchMode, EchStatus, Resumption,

--- a/ci-bench/src/benchmark.rs
+++ b/ci-bench/src/benchmark.rs
@@ -1,7 +1,7 @@
-use std::sync::Arc;
-
 use fxhash::FxHashMap;
 use itertools::Itertools;
+
+use rustls::Arc;
 
 use crate::callgrind::InstructionCounts;
 use crate::util::KeyType;

--- a/ci-bench/src/main.rs
+++ b/ci-bench/src/main.rs
@@ -5,7 +5,6 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::mem;
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Context;
@@ -15,6 +14,9 @@ use fxhash::FxHashMap;
 use itertools::Itertools;
 use rayon::iter::Either;
 use rayon::prelude::*;
+
+use rustls::Arc;
+
 use rustls::client::Resumption;
 use rustls::crypto::{aws_lc_rs, ring, CryptoProvider, GetRandomFailed, SecureRandom};
 use rustls::pki_types::pem::PemObject;

--- a/examples/src/bin/ech-client.rs
+++ b/examples/src/bin/ech-client.rs
@@ -32,7 +32,6 @@ use std::error::Error;
 use std::fs;
 use std::io::{stdout, BufReader, Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::sync::Arc;
 
 use clap::Parser;
 use hickory_resolver::config::{ResolverConfig, ResolverOpts};
@@ -40,6 +39,9 @@ use hickory_resolver::proto::rr::rdata::svcb::{SvcParamKey, SvcParamValue};
 use hickory_resolver::proto::rr::{RData, RecordType};
 use hickory_resolver::{ResolveError, Resolver, TokioResolver};
 use log::trace;
+
+use rustls::Arc;
+
 use rustls::client::{EchConfig, EchGreaseConfig, EchMode, EchStatus};
 use rustls::crypto::aws_lc_rs;
 use rustls::crypto::aws_lc_rs::hpke::ALL_SUPPORTED_SUITES;

--- a/examples/src/bin/limitedclient.rs
+++ b/examples/src/bin/limitedclient.rs
@@ -4,7 +4,8 @@
 
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 

--- a/examples/src/bin/server_acceptor.rs
+++ b/examples/src/bin/server_acceptor.rs
@@ -8,12 +8,14 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::ops::Add;
 use std::path::PathBuf;
-use std::sync::Arc;
 use std::time::Duration;
 use std::{fs, thread};
 
 use clap::Parser;
 use rcgen::KeyPair;
+
+use rustls::Arc;
+
 use rustls::pki_types::{CertificateRevocationListDer, PrivatePkcs8KeyDer};
 use rustls::server::{Acceptor, ClientHello, ServerConfig, WebPkiClientVerifier};
 use rustls::RootCertStore;

--- a/examples/src/bin/simple_0rtt_client.rs
+++ b/examples/src/bin/simple_0rtt_client.rs
@@ -17,7 +17,8 @@ use std::env;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
 use std::str::FromStr;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, ServerName};

--- a/examples/src/bin/simple_0rtt_server.rs
+++ b/examples/src/bin/simple_0rtt_server.rs
@@ -15,8 +15,9 @@
 use std::error::Error as StdError;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::Arc;
 use std::{env, io};
+
+use rustls::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/examples/src/bin/simpleclient.rs
+++ b/examples/src/bin/simpleclient.rs
@@ -10,7 +10,8 @@
 
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::RootCertStore;
 

--- a/examples/src/bin/simpleserver.rs
+++ b/examples/src/bin/simpleserver.rs
@@ -11,7 +11,8 @@ use std::env;
 use std::error::Error as StdError;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/examples/src/bin/tlsclient-mio.rs
+++ b/examples/src/bin/tlsclient-mio.rs
@@ -21,11 +21,13 @@
 
 use std::io::{self, Read, Write};
 use std::net::ToSocketAddrs;
-use std::sync::Arc;
 use std::{process, str};
 
 use clap::Parser;
 use mio::net::TcpStream;
+
+use rustls::Arc;
+
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};

--- a/examples/src/bin/tlsserver-mio.rs
+++ b/examples/src/bin/tlsserver-mio.rs
@@ -22,12 +22,14 @@
 use std::collections::HashMap;
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::{fs, net};
 
 use clap::{Parser, Subcommand};
 use log::{debug, error};
 use mio::net::{TcpListener, TcpStream};
+
+use rustls::Arc;
+
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, CertificateRevocationListDer, PrivateKeyDer};

--- a/examples/src/bin/unbuffered-async-client.rs
+++ b/examples/src/bin/unbuffered-async-client.rs
@@ -3,12 +3,14 @@
 //! using asynchronous I/O using either async-std or tokio.
 
 use std::error::Error;
-use std::sync::Arc;
 
 #[cfg(feature = "async-std")]
 use async_std::io::{ReadExt, WriteExt};
 #[cfg(feature = "async-std")]
 use async_std::net::TcpStream;
+
+use rustls::Arc;
+
 use rustls::client::{ClientConnectionData, UnbufferedClientConnection};
 use rustls::unbuffered::{
     AppDataRecord, ConnectionState, EncodeError, EncryptError, InsufficientSizeError,

--- a/examples/src/bin/unbuffered-client.rs
+++ b/examples/src/bin/unbuffered-client.rs
@@ -4,7 +4,8 @@
 use std::error::Error;
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::client::{ClientConnectionData, EarlyDataError, UnbufferedClientConnection};
 use rustls::unbuffered::{

--- a/examples/src/bin/unbuffered-server.rs
+++ b/examples/src/bin/unbuffered-server.rs
@@ -6,7 +6,8 @@ use std::error::Error;
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -177,6 +177,9 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "portable-atomic"

--- a/fuzz/fuzzers/client.rs
+++ b/fuzz/fuzzers/client.rs
@@ -4,7 +4,8 @@ extern crate libfuzzer_sys;
 extern crate rustls;
 
 use std::io;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::{ClientConfig, ClientConnection};
 

--- a/fuzz/fuzzers/server.rs
+++ b/fuzz/fuzzers/server.rs
@@ -4,7 +4,8 @@ extern crate libfuzzer_sys;
 extern crate rustls;
 
 use std::io;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::server::{Accepted, Acceptor};
 use rustls::{ServerConfig, ServerConnection};

--- a/openssl-tests/src/ffdhe_kx_with_openssl.rs
+++ b/openssl-tests/src/ffdhe_kx_with_openssl.rs
@@ -1,9 +1,11 @@
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::sync::Arc;
 use std::{fs, str, thread};
 
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
+
+use rustls::Arc;
+
 use rustls::crypto::{aws_lc_rs as provider, CryptoProvider};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};

--- a/openssl-tests/src/raw_key_openssl_interop.rs
+++ b/openssl-tests/src/raw_key_openssl_interop.rs
@@ -7,7 +7,8 @@
 mod client {
     use std::io::{self, Read, Write};
     use std::net::TcpStream;
-    use std::sync::Arc;
+
+    use rustls::Arc;
 
     use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
     use rustls::client::AlwaysResolvesClientRawPublicKeys;
@@ -158,7 +159,8 @@ mod client {
 mod server {
     use std::io::{self, ErrorKind, Read, Write};
     use std::net::TcpListener;
-    use std::sync::Arc;
+
+    use rustls::Arc;
 
     use rustls::client::danger::HandshakeSignatureValid;
     use rustls::crypto::{

--- a/provider-example/examples/client.rs
+++ b/provider-example/examples/client.rs
@@ -1,6 +1,7 @@
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 fn main() {
     env_logger::init();

--- a/provider-example/examples/server.rs
+++ b/provider-example/examples/server.rs
@@ -1,5 +1,6 @@
 use std::io::Write;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::Acceptor;

--- a/provider-example/src/hpke.rs
+++ b/provider-example/src/hpke.rs
@@ -8,6 +8,10 @@ use hpke_rs_rust_crypto::HpkeRustCrypto;
 use rustls::crypto::hpke::{
     EncapsulatedSecret, Hpke, HpkeOpener, HpkePrivateKey, HpkePublicKey, HpkeSealer, HpkeSuite,
 };
+
+#[cfg(feature = "std")]
+use rustls::Arc;
+
 use rustls::internal::msgs::enums::{
     HpkeAead as HpkeAeadId, HpkeKdf as HpkeKdfId, HpkeKem as HpkeKemId, HpkeKem,
 };
@@ -213,7 +217,7 @@ impl HpkeOpener for HpkeRsReceiver {
 
 #[cfg(feature = "std")]
 fn other_err(err: impl std::error::Error + Send + Sync + 'static) -> Error {
-    Error::Other(OtherError(alloc::sync::Arc::new(err)))
+    Error::Other(OtherError(Arc::new(err)))
 }
 
 #[cfg(not(feature = "std"))]

--- a/provider-example/src/lib.rs
+++ b/provider-example/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-use alloc::sync::Arc;
+use rustls::Arc;
 
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::PrivateKeyDer;

--- a/provider-example/src/sign.rs
+++ b/provider-example/src/sign.rs
@@ -1,8 +1,10 @@
 use alloc::boxed::Box;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use pkcs8::DecodePrivateKey;
+
+use rustls::Arc;
+
 use rustls::pki_types::PrivateKeyDer;
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};

--- a/rustls-bench/src/main.rs
+++ b/rustls-bench/src/main.rs
@@ -7,11 +7,13 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::num::NonZeroUsize;
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{mem, thread};
 
 use clap::{Parser, ValueEnum};
+
+use rustls::Arc;
+
 use rustls::client::{Resumption, UnbufferedClientConnection};
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::pem::PemObject;

--- a/rustls-fuzzing-provider/src/lib.rs
+++ b/rustls-fuzzing-provider/src/lib.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use rustls::Arc;
 
 use rustls::client::danger::ServerCertVerifier;
 use rustls::client::WebPkiServerVerifier;
@@ -21,6 +21,7 @@ use rustls::{
     PeerMisbehaved, ProtocolVersion, RootCertStore, SignatureAlgorithm, SignatureScheme,
     SupportedCipherSuite, Tls12CipherSuite, Tls13CipherSuite,
 };
+
 use webpki::alg_id;
 
 /// This is a `CryptoProvider` that provides NO SECURITY and is for fuzzing only.

--- a/rustls-post-quantum/benches/benchmarks.rs
+++ b/rustls-post-quantum/benches/benchmarks.rs
@@ -1,6 +1,7 @@
-use std::sync::Arc;
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+
+use rustls::Arc;
+
 use rustls::crypto::aws_lc_rs::kx_group::X25519;
 use rustls::crypto::{
     aws_lc_rs, ActiveKeyExchange, CryptoProvider, SharedSecret, SupportedKxGroup,

--- a/rustls-post-quantum/examples/client.rs
+++ b/rustls-post-quantum/examples/client.rs
@@ -9,7 +9,8 @@
 
 use std::io::{stdout, Read, Write};
 use std::net::TcpStream;
-use std::sync::Arc;
+
+use rustls::Arc;
 
 fn main() {
     env_logger::init();

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -48,9 +48,9 @@ log = { workspace = true, optional = true }
 # in the error result from `crypto::CryptoProvider::set_default()`, which does not seem
 # worth using the `critical-section` feature with its no-std installation requirements.
 # TODO: specify `once_cell` version in single place - as RECENTLY UPDATED in upstream RUSTLS
+# XXX XXX MUST SPECIFY FEATURES HERE DUE TO UPDATED CONFIG
 # (It may be best to specify the `once_cell` features here, as may be needed for updates moving forward.)
-once_cell = { version = "1.20.3", default-features = false, features = ["alloc", "race"] }
-# TODO: KEEP `portable-atomic-util` OPTIONAL WITH FEATURE CONFIG IN THIS FORK
+once_cell = { version = "1.20.3", default-features = false, features = ["alloc", "portable-atomic", "race"] }
 portable-atomic-util = { version = "0.2.4", default-features = false, features = ["alloc"] }
 ring = { workspace = true, optional = true }
 subtle = { workspace = true }
@@ -129,6 +129,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [
   # ---
+  "portable_atomic_util::arc::Arc",
   "rustls_pki_types",
   "rustls_pki_types::*",
 ]

--- a/rustls/benches/benchmarks.rs
+++ b/rustls/benches/benchmarks.rs
@@ -6,9 +6,10 @@ use rustls::crypto::ring as provider;
 #[path = "../tests/common/mod.rs"]
 mod test_utils;
 use std::io;
-use std::sync::Arc;
 
 use portable_rustls as rustls; // TEST IMPORT WORKAROUND for this fork
+
+use rustls::Arc;
 
 use rustls::ServerConnection;
 use test_utils::*;

--- a/rustls/src/crypto/mod.rs
+++ b/rustls/src/crypto/mod.rs
@@ -125,7 +125,7 @@ pub use crate::suites::CipherSuiteCommon;
 /// ```
 /// # #[cfg(feature = "aws_lc_rs")] {
 /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
-/// # use std::sync::Arc;
+/// # use rustls::Arc;
 /// # mod fictious_hsm_api { pub fn load_private_key(key_der: pki_types::PrivateKeyDer<'static>) -> ! { unreachable!(); } }
 /// use rustls::crypto::aws_lc_rs;
 ///

--- a/rustls/src/lib.rs
+++ b/rustls/src/lib.rs
@@ -256,8 +256,8 @@
 //! ```rust
 //! # #[cfg(feature = "aws_lc_rs")] {
 //! # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
+//! # use rustls::Arc;
 //! # use webpki;
-//! # use std::sync::Arc;
 //! # rustls::crypto::aws_lc_rs::default_provider().install_default();
 //! # let root_store = rustls::RootCertStore::from_iter(
 //! #  webpki_roots::TLS_SERVER_ROOTS
@@ -512,13 +512,28 @@ mod test_macros;
 /// of rustls targetting architectures without atomic pointers to replace the implementation
 /// with another implementation such as `portable_atomic_util::Arc` in one central location.
 mod sync {
+    // Arc alias as exported by public API below
+    pub(crate) use crate::Arc;
+}
+
+mod arc_alias {
+    // XXX TBD XXX XXX XXX
+    // XXX TODO UPDATE DOC
+    // XXX XXX NOTE THAT THIS USES SEPARATE cfg option per Arc option - EXACTLY ONE is required to build & test
+    // NOTE that unstable_use_arc_from_stdlib option is NOT DOCUMENTED and NOT SUPPORTED - primary purpose is for extra testing
     #[cfg(unstable_portable_atomic_arc)]
     #[allow(clippy::disallowed_types)]
     pub(crate) type Arc<T> = portable_atomic_util::Arc<T>;
-    #[cfg(not(unstable_portable_atomic_arc))]
+    #[cfg(unstable_use_arc_from_stdlib)]
     #[allow(clippy::disallowed_types)]
     pub(crate) type Arc<T> = alloc::sync::Arc<T>;
 }
+
+/// Arc alias for this entire crate - may alias to either of these depending on the cfg used when building:
+/// - [`portable_atomic_util::Arc`](https://docs.rs/portable-atomic-util/latest/portable_atomic_util/struct.Arc.html)
+/// - [`alloc::sync::Arc`]
+#[allow(unused_qualifications)]
+pub type Arc<T> = crate::arc_alias::Arc<T>;
 
 #[macro_use]
 mod msgs;

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -732,9 +732,10 @@ mod connection {
     /// ```no_run
     /// # #[cfg(feature = "aws_lc_rs")] {
     /// # use portable_rustls as rustls; // DOC IMPORT WORKAROUND for this fork
+    /// # use rustls::Arc;
     /// # fn choose_server_config(
     /// #     _: rustls::server::ClientHello,
-    /// # ) -> std::sync::Arc<rustls::ServerConfig> {
+    /// # ) -> Arc<rustls::ServerConfig> {
     /// #     unimplemented!();
     /// # }
     /// # #[allow(unused_variables)]

--- a/rustls/tests/common/mod.rs
+++ b/rustls/tests/common/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 #![allow(clippy::duplicate_mod)]
-// QUICK CLIPPY WORKAROUND for `unstable_portable_atomic_arc` IN THIS FORK
+// QUICK CLIPPY WORKAROUND for `unstable_use_arc_from_stdlib` IN THIS FORK
 #![allow(unexpected_cfgs)]
 
 use std::io;
@@ -38,10 +38,7 @@ use webpki::anchor_from_trusted_cert;
 use super::provider;
 
 // UPDATED IN THIS FORK (THIS IMPORT ONLY SEEMS TO BE NEEDED FOR `aws_lc_rs` & `ring` features)
-#[cfg(unstable_portable_atomic_arc)]
-pub use portable_atomic_util::Arc;
-#[cfg(not(unstable_portable_atomic_arc))]
-pub use std::sync::Arc;
+pub use rustls::Arc;
 
 macro_rules! embed_files {
     (


### PR DESCRIPTION
Contains the following updates:

- export Arc alias - from other PR #44
- additional `unstable_use_arc_from_stdlib` cfg option to select using `alloc::sync::Arc` / `std::sync::Arc` - based on other PR #49
- use `once_cell` dependency with `portable-atomic` feature enabled - update from other PR #49
- update bench tests, examples, etc. to use exported `Arc` alias
- CI testing updates to test with cfg option for `portable_atomic_util::Arc` vs `alloc::sync::Arc`

MISSING documentation updates

This update implies that build needs to be done with exactly one of the following cfg options:

- `--cfg=unstable_portable_atomic_arc` to use `portable_atomic_util::Arc`
- `--cfg=unstable_use_arc_from_stdlib` to use `alloc::sync::Arc``

CI testing was updated to include both `RUSTFLAGS` and `RUSTDOCFLAGS` in many cases, using `--cfg=...` as needed for doc tests in multiple cases.

MOTIVATION is to evaluate how CI testing works with cfg options in RUSTFLAGS & RUSTDOCFLAGS & prepare for more build options in the future.

I came up with this experimental scenario while working on something else for other PRs #44 and #49. It looks to me like Rust Cargo tooling is stricter with flags for doc tests than for normal unit tests.

I think the Rust Cargo tooling should be updated to make this simpler and reduce the chance of someone testing with the wrong cfg options in doc testing.

---

NOTE that the updates in this PR are based on updates I tried out in a personal WIP branch. Yes the commit(s) may contain a weird combo of code, example, and testing updates.