### PR TITLE
[portable-rustls] CI improvements - DRAFT DO NOT MERGE

### DIFF
--- a/.github/workflows/portable-rustls-ci-build.yml
+++ b/.github/workflows/portable-rustls-ci-build.yml
@@ -26,6 +26,7 @@ jobs:
     name: build with unstable_portable_atomic_arc
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # XXX XXX XXX
       matrix:
         rust:
           - nightly
@@ -80,6 +81,7 @@ jobs:
     name: test with unstable_portable_atomic_arc
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # XXX XXX XXX
       matrix:
         rust:
           - nightly
@@ -227,6 +229,7 @@ jobs:
     name: full build with unstable_portable_atomic_arc cfg
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # XXX XXX XXX
       matrix:
         rust:
           - nightly
@@ -274,6 +277,7 @@ jobs:
     name: full test with unstable_portable_atomic_arc cfg
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # XXX XXX XXX
       matrix:
         rust:
           - nightly

--- a/.github/workflows/portable-rustls-ci-build.yml
+++ b/.github/workflows/portable-rustls-ci-build.yml
@@ -33,8 +33,11 @@ jobs:
           - nightly-2024-01-01
           # RUST NIGHTLY version(s) for MSRV - 1.71:
           - nightly-2023-06-01
+          # XXX TBD ???
           # FAILS AT: cargo add once_cell
-          # - nightly-2023-05-01
+          - nightly-2023-05-01
+          - nightly-2023-04-01
+          - nightly-2023-01-01
         os:
           - ubuntu-latest
           # FOR FUTURE CONSIDERATION:
@@ -89,8 +92,12 @@ jobs:
           - nightly-2024-07-01
           # TEST with LIMITED FEATURES back to:
           - nightly-2024-05-01
+          # XXX TBD ??? ???
           # FAILS cargo test: use of unstable library feature in proc-macro2
-          # - nightly-2024-04-01
+          - nightly-2024-04-01
+          - nightly-2024-01-01
+          - nightly-2023-12-01
+          - nightly-2023-09-01
         os:
           - ubuntu-latest
           - macos-latest
@@ -241,8 +248,9 @@ jobs:
           # - nightly-2023-11-01
           # OK WITH NO FEATURES ENABLED (issue with --all-features due to `zlib`)
           - nightly-2023-10-01
+          # XXX TBD ???
           # KNOWN BUILD FAILURE
-          # - nightly-2023-09-01
+          - nightly-2023-09-01
         os:
           - ubuntu-latest
           # FOR FUTURE CONSIDERATION:
@@ -282,8 +290,10 @@ jobs:
         rust:
           - nightly
           - nightly-2024-07-01
+          # XXX TBD ???
           # TEST BUILD FAILURE WITH OLDER RUST NIGHTLY VERSIONS
-          # - nightly-2024-06-01
+          - nightly-2024-06-01
+          - nightly-2024-01-01
           # ...
         os:
           - ubuntu-latest

--- a/rustls/src/crypto/aws_lc_rs/ticketer.rs
+++ b/rustls/src/crypto/aws_lc_rs/ticketer.rs
@@ -340,7 +340,7 @@ mod tests {
 
     #[test]
     fn ticketswitcher_switching_test() {
-        #[expect(deprecated)]
+        #[cfg_attr(not(test), expect(deprecated))]
         let t = Arc::new(crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap());
         let now = UnixTime::now();
         let cipher1 = t.encrypt(b"ticket 1").unwrap();
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn ticketswitcher_recover_test() {
-        #[expect(deprecated)]
+        #[cfg_attr(not(test), expect(deprecated))]
         let mut t = crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap();
         let now = UnixTime::now();
         let cipher1 = t.encrypt(b"ticket 1").unwrap();

--- a/rustls/src/crypto/ring/ticketer.rs
+++ b/rustls/src/crypto/ring/ticketer.rs
@@ -305,7 +305,7 @@ mod tests {
 
     #[test]
     fn ticketswitcher_switching_test() {
-        #[expect(deprecated)]
+        #[cfg_attr(not(test), expect(deprecated))]
         let t = Arc::new(crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap());
         let now = UnixTime::now();
         let cipher1 = t.encrypt(b"ticket 1").unwrap();
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn ticketswitcher_recover_test() {
-        #[expect(deprecated)]
+        #[cfg_attr(not(test), expect(deprecated))]
         let mut t = crate::ticketer::TicketSwitcher::new(1, make_ticket_generator).unwrap();
         let now = UnixTime::now();
         let cipher1 = t.encrypt(b"ticket 1").unwrap();


### PR DESCRIPTION
- test workarounds to test with some older Rust nightly versions
- TODO: RUSTFLAGS is sometimes duplicated among consecutive steps in some test jobs - should define once per test job if possible
- TODO: clear explanations for "QUICK WORKAROUNDS" needed in CI
- TODO: other ideas (???)

__STATUS:__ known CI clippy job failure - may need some rework to resolve this 