### PR TITLE
EXPERIMENTAL DRAFT RFC: use rustix for no-std DefaultTimeProvider - EXPERIMENTAL DRAFT DO NOT MERGE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
     name: Build+test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # XXX
       matrix:
         rust:
           - stable
@@ -43,11 +44,12 @@ jobs:
             rust: stable
           - os: ubuntu-latest
             rust: beta
+          # XXX SKIP FOR NOW
           # ONLY Rust nightly on Windows - slower platform
-          - os: windows-latest
-            rust: stable
-          - os: windows-latest
-            rust: beta
+          # - os: windows-latest
+          #   rust: stable
+          # - os: windows-latest
+          #   rust: beta
           # and never use Windows for merge checks
           - os: ${{ github.event_name == 'merge_group' && 'windows-latest' }}
     steps:
@@ -156,6 +158,7 @@ jobs:
       # (may use another target with no std lib - x86_64-unknown-none for example)
       NO_STD_BUILD_TARGET: aarch64-unknown-none
     strategy:
+      fail-fast: false # XXX
       matrix:
         rust:
           - stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.43",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -1738,6 +1738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,7 +2143,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.43",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2203,6 +2209,7 @@ dependencies = [
  "portable-atomic-util",
  "rcgen",
  "ring",
+ "rustix 1.0.1",
  "rustls-pki-types",
  "rustls-webpki",
  "rustversion",
@@ -2501,7 +2508,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
 
@@ -3263,7 +3283,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.43",
 ]
 
 [[package]]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -97,6 +97,7 @@ webpki = { workspace = true }
 pki-types = { workspace = true }
 zeroize = { workspace = true }
 zlib-rs = { workspace = true, optional = true }
+rustix = { version = "1.0.1", default-features = false, features = ["time"] }
 
 [dev-dependencies]
 base64 = { workspace = true }

--- a/rustls/src/client/client_conn.rs
+++ b/rustls/src/client/client_conn.rs
@@ -20,7 +20,6 @@ use crate::msgs::handshake::ClientExtension;
 use crate::msgs::persist;
 use crate::suites::SupportedCipherSuite;
 use crate::sync::Arc;
-#[cfg(feature = "std")]
 use crate::time_provider::DefaultTimeProvider;
 use crate::time_provider::TimeProvider;
 use crate::unbuffered::{EncryptError, TransmitTlsData};
@@ -317,7 +316,6 @@ impl ClientConfig {
     /// version is not supported by the provider's ciphersuites.
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
-    #[cfg(feature = "std")]
     pub fn builder_with_provider(
         provider: Arc<CryptoProvider>,
     ) -> ConfigBuilder<Self, WantsVersions> {

--- a/rustls/src/server/server_conn.rs
+++ b/rustls/src/server/server_conn.rs
@@ -26,7 +26,6 @@ use crate::msgs::enums::CertificateType;
 use crate::msgs::handshake::{ClientHelloPayload, ProtocolName, ServerExtension};
 use crate::msgs::message::Message;
 use crate::sync::Arc;
-#[cfg(feature = "std")]
 use crate::time_provider::DefaultTimeProvider;
 use crate::time_provider::TimeProvider;
 use crate::vecbuf::ChunkVecBuffer;
@@ -443,7 +442,6 @@ impl ServerConfig {
     /// version is not supported by the provider's ciphersuites.
     ///
     /// For more information, see the [`ConfigBuilder`] documentation.
-    #[cfg(feature = "std")]
     pub fn builder_with_provider(
         provider: Arc<CryptoProvider>,
     ) -> ConfigBuilder<Self, WantsVersions> {

--- a/rustls/src/time_provider.rs
+++ b/rustls/src/time_provider.rs
@@ -18,13 +18,16 @@ pub trait TimeProvider: Debug + Send + Sync {
 }
 
 #[derive(Debug)]
-#[cfg(feature = "std")]
 /// Default `TimeProvider` implementation that uses `std`
 pub struct DefaultTimeProvider;
 
-#[cfg(feature = "std")]
 impl TimeProvider for DefaultTimeProvider {
     fn current_time(&self) -> Option<UnixTime> {
-        Some(UnixTime::now())
+        let clock_time = rustix::time::clock_gettime(rustix::time::ClockId::Realtime);
+        Some(UnixTime::since_unix_epoch(core::time::Duration::new(
+            clock_time.tv_sec.try_into().unwrap(),
+            // XXX TBD IS THIS IGNORED ??? ??? ???
+            clock_time.tv_nsec.try_into().unwrap(),
+        )))
     }
 }


### PR DESCRIPTION
I think it would be really nice if could build for an embedded no-std target such as ESP32 without needing to to implement a time provider just to get started with some of the most commonly-used API.

This is an initial experiment that shows `DefaultTimeProvider` building for no-std. While I do not expect this experiment to add anything valuable by itself, I think this could be a helpful starting point for using libc::clock_gettime in some form. It would probably be best to find & reuse a smaller library for this call, if possible, since this is considered unsafe which is always denied (and I would rather not change this). Here are some alternative ideas that I have found so far:
- https://users.rust-lang.org/t/fast-get-current-time/10381 - this has some basic ideas and links to a couple libraries. Unfortunately none of these libraries seem to solve this at this point:
  - https://crates.io/crates/amd64_timer - CPU specific, may be nice in some other kind of wrapper
  - https://github.com/jedisct1/rust-coarsetime - I tried this out, looks nice but unfortunately does not seem to support no-std
- https://github.com/FluenTech/embedded-time - found via https://stackoverflow.com/questions/76251222/get-elapsed-time-since-some-instant-in-embedded-rust but it looks to me like it does not actually get the clock time, as needed for this to work
- https://github.com/korken89/fugit - used by [esp-rs, ](https://github.com/esp-rs/esp-hal also looks like it does not get the clock time
- https://gist.github.com/lifthrasiir/393ffb3e9900709fa2e3ae2a540b635f - this shows the libc calls needed to get the clock time more directly

I will probably put this on hold for now, just wanted to try this as an experiment.