### PR TITLE
EXTRA EXPERIMENT: use coarsetime to support DefaultTimeProvider API functions for no-std - DO NOT MERGE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
     name: Build+test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false # XXX
       matrix:
         rust:
           - stable
@@ -156,6 +157,7 @@ jobs:
       # (may use another target with no std lib - x86_64-unknown-none for example)
       NO_STD_BUILD_TARGET: aarch64-unknown-none
     strategy:
+      fail-fast: false # XXX
       matrix:
         rust:
           - stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "coarsetime"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91849686042de1b41cd81490edc83afbcb0abe5a9b6f2c4114f23ce8cca1bcf4"
+dependencies = [
+ "libc",
+ "wasix",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,6 +2203,7 @@ dependencies = [
  "bencher",
  "brotli",
  "brotli-decompressor",
+ "coarsetime",
  "env_logger",
  "hashbrown",
  "hex",
@@ -3162,6 +3174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasix"
+version = "0.12.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fbb4ef9bbca0c1170e0b00dd28abc9e3b68669821600cad1caaed606583c6d"
+dependencies = [
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]

--- a/rustls/Cargo.toml
+++ b/rustls/Cargo.toml
@@ -98,6 +98,9 @@ pki-types = { workspace = true }
 zeroize = { workspace = true }
 zlib-rs = { workspace = true, optional = true }
 
+# XXX TBD ORDERING ???
+coarsetime = { version = "0.1.36", default-features = false }
+
 [dev-dependencies]
 base64 = { workspace = true }
 bencher = { workspace = true }

--- a/rustls/src/time_provider.rs
+++ b/rustls/src/time_provider.rs
@@ -25,6 +25,11 @@ pub struct DefaultTimeProvider;
 #[cfg(feature = "std")]
 impl TimeProvider for DefaultTimeProvider {
     fn current_time(&self) -> Option<UnixTime> {
-        Some(UnixTime::now())
+        Some(UnixTime::since_unix_epoch(core::time::Duration::new(
+            // XXX TBD ??? - IS THIS TRUE ON ALL TARGETS ??? ??? ???
+            coarsetime::Instant::now().as_ticks() / 1000 / 1000,
+            // XXX TBD ??? ??? ??? - IS VALUE NEEDED HERE ????
+            0,
+        )))
     }
 }


### PR DESCRIPTION
Similar idea to other PR: #57

I think it would be really nice if could build for an embedded no-std target such as ESP32 without needing to to implement a time provider just to get started with some of the most commonly-used API.

The following Q&A pointed me to coarsetime: https://users.rust-lang.org/t/fast-get-current-time/10381

Unfortunately it looks to me like coarsetime does not support no-std. I suspect it may be possible to update coarsetime to support no-std with a limited number of updates. Other open question is getting libc to support reading the system clock on no-std targets, still needs investigation.

This will likely stay on hold for now, just wanted to raise this as an idea for future consideration.